### PR TITLE
Okay this is very techincal

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -97,11 +97,16 @@ int main() {
         std::cout << "\n[1/6] INSERT THROUGHPUT\n";
         print_separator();
 
+        // Pre-generate all vectors so RNG cost is excluded from the timed section
+        std::cout << "   Pre-generating " << NUM_VECTORS << " vectors...\n";
+        std::vector<std::vector<float>> vectors(NUM_VECTORS);
+        for (auto& v : vectors) v = rand_vec(DIMENSIONS);
+
         CoreEngine::RedBoxVector db(db_name + ".db", DIMENSIONS, NUM_VECTORS);
 
         auto t0 = Clock::now();
         for (int i = 0; i < NUM_VECTORS; ++i)
-            db.insert_auto(rand_vec(DIMENSIONS));
+            db.insert_auto(vectors[i]);
         auto t1 = Clock::now();
 
         double secs = std::chrono::duration<double>(t1 - t0).count();
@@ -112,6 +117,7 @@ int main() {
         std::cout << "   Time       : " << std::fixed << std::setprecision(3) << secs << " s\n";
         std::cout << "   Throughput : " << (long long)rate << " vectors/sec\n";
         std::cout << "   Data Size  : " << std::setprecision(1) << bytes_mb << " MB written\n";
+        std::cout << "   (RNG excluded from timing)\n";
     }
 
     // ==========================================
@@ -349,6 +355,8 @@ int main() {
         std::cout << "   QPS  : " << std::fixed << std::setprecision(1)
                   << (NUM_QUERIES / total_secs) << " queries/sec\n";
         print_stats(s);
+        std::cout << "   (Compare QPS/P99 against Bench 2 to see deleted_flags impact)\n";
+
         cleanup(db_name);
     }
 

--- a/include/redboxdb/SpecificMetadata.hpp
+++ b/include/redboxdb/SpecificMetadata.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 namespace CoreEngine {
     struct SpecificMetadata {
@@ -7,6 +8,11 @@ namespace CoreEngine {
         uint64_t dimensions;      // DYNAMIC!
         uint64_t data_type_size;  // 4 (float)
         uint64_t next_id;
-        uint8_t _padding[88];    // Future proofing
+        uint8_t  version;         // Layout version. 0 = legacy interleaved, 1 = columnar
+        uint8_t  _padding[87];    // Future proofing — struct stays 128 bytes
+
+        static constexpr uint8_t CURRENT_VERSION = 1;
     };
+
+    static_assert(sizeof(SpecificMetadata) == 128, "SpecificMetadata must be exactly 128 bytes");
 }

--- a/include/redboxdb/storage_manager.hpp
+++ b/include/redboxdb/storage_manager.hpp
@@ -11,30 +11,33 @@ namespace StorageManager {
 
     class Manager {
     private:
-        size_t allocated_size;
+        size_t      allocated_size;
         std::string filename;
-        HANDLE hFile;
-        HANDLE hMapFile;
-        void* map_base;
+        HANDLE      hFile;
+        HANDLE      hMapFile;
+        void*       map_base;
 
         CoreEngine::SpecificMetadata* header;
 
-        char* data_start;
-        size_t row_size_bytes;
-
+        // Columnar layout (version 1):
+        //   [ Header (128 bytes) ]
+        //   [ ID block:    capacity * sizeof(uint64_t) ]
+        //   [ Float block: capacity * dimensions * sizeof(float) ]
+        uint64_t* id_block;    // points to start of ID column
+        float*    float_block; // points to start of float column
 
     public:
         Manager(const std::string& db_file, uint64_t dimensions, int initial_capacity);
         ~Manager();
 
-        void add_vector(uint64_t id, const std::vector<float>& vec);
-        std::pair<uint64_t, const float*> get_vector_raw(int index);
-        uint64_t get_count() const;
-        
-        uint64_t next_id();
+        void             add_vector(uint64_t id, const std::vector<float>& vec);
+        const float*     get_float_ptr(int index) const;
+        float*           get_float_ptr_mut(int index);
+        uint64_t         get_id(int index) const;
+        uint64_t         get_count() const;
+        uint64_t         next_id();
     };
 }
-
 
 
 /*
@@ -42,17 +45,19 @@ namespace StorageManager {
 */
 
 
-
-
 /*
-    
-    So every database file's size will ofc depened on the database
+    Columnar layout (version 1):
 
-  [ Header (24 bytes) ] [ Vector 0 ] [ Vector 1 ] [ Vector 2 ] ...
-    ^                      ^
-    Start of mmap          Start of data = (Start + 24)  Next vector = (Start + 24 + 4096)
+    [ Header (128 bytes) ] [ ID block ] [ Float block ]
+      ^                      ^             ^
+      Start of mmap          +128          +128 + capacity*8
 
-    Every vector will be metadata.dimentions * metadata.data_type_size = say 1024 * 4byte = 4096 byte or 1024 * 32 bits = 32768 bits
-    I can just work with bytes
+    ID block:    capacity * 8  bytes  (one uint64_t per slot)
+    Float block: capacity * dim * 4 bytes (dim floats per slot)
 
+    Slot i:
+      id_block[i]                          -> the vector's ID
+      float_block + i * dimensions         -> pointer to its floats
+
+    Search loop only touches float_block — IDs are never read during scan.
 */

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -23,7 +23,7 @@ namespace CoreEngine {
         int existing = static_cast<int>(_manager->get_count());
         deleted_flags.resize(existing, 0);
         for (int i = 0; i < existing; ++i) {
-            auto [id, _] = _manager->get_vector_raw(i);
+            uint64_t id = _manager->get_id(i);
             if (deleted_ids.count(id))
                 deleted_flags[i] = 1;
             else
@@ -37,13 +37,13 @@ namespace CoreEngine {
     // -----------------------------------------------------------------------
     void RedBoxVector::insert(uint64_t id, const std::vector<float>& vec) {
         if (deleted_ids.count(id)) {
-            // clear the old slots flag, it stays in the mmap as a zombie,
+            // Clear the old slot's flag — it stays in the mmap as a zombie,
             // but we don't want it showing up as deleted in scans anymore.
             auto old_it = id_to_index.find(id); // not present (erased on remove)
             // old slot flag: we don't have the index anymore, so we can't clear it.
             // It will be skipped correctly: the new append below gets flag=0,
             // and the old zombie slot has no entry in id_to_index so update()
-            // won't touch it. The flag on the old slot stays 1 (correct : it IS
+            // won't touch it. The flag on the old slot stays 1 (correct — it IS
             // a dead row). The new row gets flag=0.
             (void)old_it;
             deleted_ids.erase(id);
@@ -77,20 +77,19 @@ namespace CoreEngine {
     // -----------------------------------------------------------------------
     int RedBoxVector::search(const std::vector<float>& query) {
         float min_dist = 1e9f;
-        int   best_id = -1;
         int   count = static_cast<int>(_manager->get_count());
-
+        int   best_slot = -1;
         for (int i = 0; i < count; ++i) {
             if (deleted_flags[i]) continue;
-            auto [id, vec_ptr] = _manager->get_vector_raw(i);
-
+            const float* vec_ptr = _manager->get_float_ptr(i);
             float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
             if (dist < min_dist) {
                 min_dist = dist;
-                best_id = static_cast<int>(id);
+                best_slot = i;
             }
         }
-        return best_id;
+        if (best_slot == -1) return -1;
+        return static_cast<int>(_manager->get_id(best_slot));
     }
 
     // -----------------------------------------------------------------------
@@ -178,23 +177,23 @@ namespace CoreEngine {
 
         for (int i = 0; i < count; ++i) {
             if (deleted_flags[i]) continue;
-            auto [id, vec_ptr] = _manager->get_vector_raw(i);
-
+            const float* vec_ptr = _manager->get_float_ptr(i);
             float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
 
             if ((int)pq.size() < N) {
-                pq.push({ dist, static_cast<int>(id) });
+                pq.push({ dist, i }); // store slot index, resolve to ID after scan
             }
             else if (dist < pq.top().first) {
                 pq.pop();
-                pq.push({ dist, static_cast<int>(id) });
+                pq.push({ dist, i });
             }
         }
 
         std::vector<int> result;
         result.reserve(pq.size());
         while (!pq.empty()) {
-            result.push_back(pq.top().second);
+            int slot = pq.top().second;
+            result.push_back(static_cast<int>(_manager->get_id(slot)));
             pq.pop();
         }
         std::reverse(result.begin(), result.end());
@@ -212,8 +211,7 @@ namespace CoreEngine {
         auto it = id_to_index.find(id);
         if (it == id_to_index.end()) return false;
 
-        auto record = _manager->get_vector_raw(static_cast<int>(it->second));
-        float* dst = const_cast<float*>(record.second);
+        float* dst = _manager->get_float_ptr_mut(static_cast<int>(it->second));
         std::memcpy(dst, vec.data(), dimension * sizeof(float));
         return true;
     }
@@ -222,15 +220,25 @@ namespace CoreEngine {
 
 
 // ============================================================
-// StorageManager — unchanged from original, kept in same TU
+// StorageManager — Columnar layout (version 1)
 // ============================================================
 namespace StorageManager {
-        Manager::Manager(const std::string& db_file, size_t dimensions, int initial_capacity)
-            : allocated_size(initial_capacity), filename(db_file),
-            hFile(NULL), hMapFile(NULL), map_base(nullptr)
-        {
-        row_size_bytes = sizeof(uint64_t) + (dimensions * sizeof(float));
 
+    // Helper: set up id_block and float_block pointers from map_base
+    static void setup_pointers(void* map_base, uint64_t capacity,
+                                CoreEngine::SpecificMetadata*& header,
+                                uint64_t*& id_block, float*& float_block)
+    {
+        header      = (CoreEngine::SpecificMetadata*)map_base;
+        id_block    = (uint64_t*)((char*)map_base + sizeof(CoreEngine::SpecificMetadata));
+        float_block = (float*)((char*)id_block + capacity * sizeof(uint64_t));
+    }
+
+    Manager::Manager(const std::string& db_file, size_t dimensions, int initial_capacity)
+        : allocated_size(initial_capacity), filename(db_file),
+          hFile(NULL), hMapFile(NULL), map_base(nullptr),
+          header(nullptr), id_block(nullptr), float_block(nullptr)
+    {
         hFile = CreateFileA(filename.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL,
             OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (hFile == INVALID_HANDLE_VALUE) throw std::runtime_error("Could not open file");
@@ -238,12 +246,17 @@ namespace StorageManager {
         LARGE_INTEGER fileSize;
         GetFileSizeEx(hFile, &fileSize);
         size_t current_size = (size_t)fileSize.QuadPart;
-        size_t required_size = sizeof(CoreEngine::SpecificMetadata) +
-            (row_size_bytes * initial_capacity);
+
+        // Columnar layout size:
+        //   header + (capacity * 8) + (capacity * dim * 4)
+        size_t id_block_bytes    = (size_t)initial_capacity * sizeof(uint64_t);
+        size_t float_block_bytes = (size_t)initial_capacity * dimensions * sizeof(float);
+        size_t required_size     = sizeof(CoreEngine::SpecificMetadata)
+                                 + id_block_bytes + float_block_bytes;
 
         if (current_size == 0) {
             LARGE_INTEGER distance;
-            distance.QuadPart = required_size;
+            distance.QuadPart = (LONGLONG)required_size;
             if (!SetFilePointerEx(hFile, distance, NULL, FILE_BEGIN))
                 throw std::runtime_error("Resize failed");
             if (!SetEndOfFile(hFile))
@@ -251,27 +264,41 @@ namespace StorageManager {
         }
 
         hMapFile = CreateFileMappingA(hFile, NULL, PAGE_READWRITE, 0, 0, NULL);
+        if (!hMapFile) throw std::runtime_error("CreateFileMapping failed");
         map_base = MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, 0);
+        if (!map_base) throw std::runtime_error("MapViewOfFile failed");
 
-        header = (CoreEngine::SpecificMetadata*)map_base;
-        data_start = (char*)map_base + sizeof(CoreEngine::SpecificMetadata);
+        setup_pointers(map_base, (uint64_t)initial_capacity, header, id_block, float_block);
 
         if (current_size == 0) {
-            header->vector_count = 0;
-            header->max_capacity = initial_capacity;
-            header->dimensions = dimensions;
+            header->vector_count   = 0;
+            header->max_capacity   = initial_capacity;
+            header->dimensions     = dimensions;
             header->data_type_size = sizeof(float);
-            header->next_id = 1;
+            header->next_id        = 1;
+            header->version        = CoreEngine::SpecificMetadata::CURRENT_VERSION;
         }
         else {
+            if (header->version != CoreEngine::SpecificMetadata::CURRENT_VERSION) {
+                UnmapViewOfFile(map_base); CloseHandle(hMapFile); CloseHandle(hFile);
+                throw std::runtime_error(
+                    "Legacy database layout detected (version " +
+                    std::to_string(header->version) +
+                    "). Please recreate the database.");
+            }
             if (header->dimensions != dimensions) {
-                throw std::runtime_error("DB Dimension mismatch! File has " +
+                UnmapViewOfFile(map_base); CloseHandle(hMapFile); CloseHandle(hFile);
+                throw std::runtime_error("DB dimension mismatch! File has " +
                     std::to_string(header->dimensions));
             }
         }
     }
 
     uint64_t Manager::next_id() { return header->next_id++; }
+    // SO अहीले लाइ, we are just incremeting the id
+    // but what happens if a vector is deleted? नसोध मलाइ
+    // so definately need a way to get id's any other way then incrementing from a base value!
+    // maybe look for deleted id's first? idk फ्युचर मी पर्रोबल्म
 
     Manager::~Manager() {
         if (map_base) { FlushViewOfFile(map_base, 0); UnmapViewOfFile(map_base); }
@@ -285,25 +312,29 @@ namespace StorageManager {
         if (header->vector_count >= header->max_capacity)
             throw std::runtime_error("Database full");
 
-        size_t offset = header->vector_count * row_size_bytes;
-        char* row_ptr = data_start + offset;
-
-        *(uint64_t*)row_ptr = id;
-        float* vec_ptr = (float*)(row_ptr + sizeof(uint64_t));
-        std::memcpy(vec_ptr, vec.data(), header->dimensions * sizeof(float));
-
+        size_t slot = header->vector_count;
+        id_block[slot] = id;
+        float* dst = float_block + slot * header->dimensions;
+        std::memcpy(dst, vec.data(), header->dimensions * sizeof(float));
         header->vector_count++;
     }
 
-    std::pair<uint64_t, const float*> Manager::get_vector_raw(int index) {
+    const float* Manager::get_float_ptr(int index) const {
         if (index >= (int)header->vector_count)
             throw std::out_of_range("Index out of bounds");
+        return float_block + (size_t)index * header->dimensions;
+    }
 
-        size_t      offset = index * row_size_bytes;
-        char* row_ptr = data_start + offset;
-        uint64_t    id = *(uint64_t*)row_ptr;
-        const float* vec_ptr = (const float*)(row_ptr + sizeof(uint64_t));
-        return { id, vec_ptr };
+    float* Manager::get_float_ptr_mut(int index) {
+        if (index >= (int)header->vector_count)
+            throw std::out_of_range("Index out of bounds");
+        return float_block + (size_t)index * header->dimensions;
+    }
+
+    uint64_t Manager::get_id(int index) const {
+        if (index >= (int)header->vector_count)
+            throw std::out_of_range("Index out of bounds");
+        return id_block[index];
     }
 
     uint64_t Manager::get_count() const { return header->vector_count; }


### PR DESCRIPTION
CPUs don't fetch individual bytes from RAM. They fetch in cache lines, (usually fixed 64 byte chunks)
When you access any byte, the entire 64-byte chunk containing it gets loaded into L1/L2 cache.


The old row layout was 520 bytes per slot (for 128 dim which we are using for our benchmarking purposes)
[ uint64_t id: 8 bytes ][ float[128]: 512 bytes ]

When the search loop accessed slot i, the first cache line fetch looked like:
bytes 0-63:  [id(8)] [f0(4)] [f1(4)] [f2(4)] ... [f13(4)] [f14(partial)]

8 of those 64 bytes were the ID. The ID was read, used for nothing during distance computation, and sat in the cache line occupying space that could have held more floats. That's 8/64 = 12.5% of every cache line wasted across 100k iterations per query.


The Fix
Split into two contiguous arrays in the mmap:
[ id_block:    uint64_t[capacity] ]  — 800KB for 100k vectors
[ float_block: float[capacity * dim] ] — 48MB for 100k × 128-dim vectors

The search loop now only touches float_block. It accesses memory at:
float_block + 0 * 128    → slot 0
float_block + 1 * 128    → slot 1
float_block + 2 * 128    → slot 2

This is a stride-1 sequential access pattern over a pure float array. Every cache line fetched is 64 bytes of floats, zero wasted bytes. 

The Prefetcher Effect
The hardware prefetcher in modern CPUs monitors memory access patterns and speculatively loads cache lines before the CPU core requests them, hiding RAM latency (~100ns) behind compute time.

It works best on regular stride patterns. The old layout had a stride of 520 bytes between the start of each slot's float data, not a power of 2, not cache-line aligned. The new layout has the float data for slot i at exactly float_block + i * 512 bytes — perfectly regular, cache-line aligned. The prefetcher can get significantly ahead of the loop and have data ready before it's needed.

During the search scan, we never touch the ID block at all : we only iterate over float_block, computing L2 distance for each slot and tracking best_slot (the array index of the closest vector found so far). Once the scan is complete, we do a single lookup, id_block[best_slot], to resolve the winning slot's index back to its actual user-facing ID. One memory read for the ID total, regardless of how many vectors are in the database.

When a vector is inserted at slot i, we write the user-provided ID into id_block[i] and the float data into float_block + i * dim simultaneously, so the two arrays are always in sync — slot i in both arrays always refers to the same vector. After the search scan finds best_slot, id_block[best_slot] simply reads back whatever ID was originally written there at insert time, resolving the array position back to the user-facing ID in one memory read.