### PR TITLE
parallelize search scan across all available cores

### DIFF
--- a/include/redboxdb/engine.hpp
+++ b/include/redboxdb/engine.hpp
@@ -1,8 +1,10 @@
 ﻿#pragma once
 #include <vector>
 #include <unordered_set>
-#include "redboxdb/storage_manager.hpp"
 #include <unordered_map>
+#include <thread>
+#include <algorithm>
+#include "redboxdb/storage_manager.hpp"
 
 namespace CoreEngine {
 
@@ -27,7 +29,10 @@ namespace CoreEngine {
 
         std::unordered_map<uint64_t, size_t> id_to_index;
 
-        bool use_avx2;
+        bool   use_avx2;
+        size_t num_threads;
+
+        static constexpr int PARALLEL_THRESHOLD = 50000;
 
     public:
         RedBoxVector(std::string file_name, size_t dim, int capacity = default_capacity);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -30,8 +30,10 @@ namespace CoreEngine {
                 id_to_index[id] = i;
         }
 
-        use_avx2 = Platform::has_avx2();
-        std::cout << "[DB] AVX2: " << (use_avx2 ? "enabled" : "disabled") << "\n";
+        use_avx2    = Platform::has_avx2();
+        num_threads = std::max(1u, std::thread::hardware_concurrency());
+        std::cout << "[DB] AVX2: " << (use_avx2 ? "enabled" : "disabled")
+                  << " | Threads: " << num_threads << "\n";
     }
 
     // -----------------------------------------------------------------------
@@ -76,16 +78,58 @@ namespace CoreEngine {
 
     // -----------------------------------------------------------------------
     int RedBoxVector::search(const std::vector<float>& query) {
-        float min_dist = 1e9f;
-        int   count = static_cast<int>(_manager->get_count());
+        int count = static_cast<int>(_manager->get_count());
+        if (count == 0) return -1;
+
+        // Single-threaded for small DBs — thread overhead not worth it
+        if (count < PARALLEL_THRESHOLD || num_threads == 1) {
+            float min_dist = 1e9f;
+            int   best_slot = -1;
+            for (int i = 0; i < count; ++i) {
+                if (deleted_flags[i]) continue;
+                const float* vec_ptr = _manager->get_float_ptr(i);
+                float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
+                if (dist < min_dist) { min_dist = dist; best_slot = i; }
+            }
+            if (best_slot == -1) return -1;
+            return static_cast<int>(_manager->get_id(best_slot));
+        }
+
+        // Parallel scan — each thread scans its own slice, writes to its own slot
+        // in these arrays (no false sharing between threads, each index is independent)
+        struct ThreadResult { float min_dist; int best_slot; };
+        std::vector<ThreadResult> results(num_threads, { 1e9f, -1 });
+
+        auto worker = [&](size_t tid, int start, int end) {
+            float local_min  = 1e9f;
+            int   local_best = -1;
+            for (int i = start; i < end; ++i) {
+                if (deleted_flags[i]) continue;
+                const float* vec_ptr = _manager->get_float_ptr(i);
+                float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
+                if (dist < local_min) { local_min = dist; local_best = i; }
+            }
+            results[tid] = { local_min, local_best };
+        };
+
+        // Divide slots as evenly as possible across threads
+        std::vector<std::thread> threads;
+        threads.reserve(num_threads);
+        int slice = count / (int)num_threads;
+        for (size_t t = 0; t < num_threads; ++t) {
+            int start = (int)t * slice;
+            int end   = (t == num_threads - 1) ? count : start + slice;
+            threads.emplace_back(worker, t, start, end);
+        }
+        for (auto& th : threads) th.join();
+
+        // Reduce: find global winner across all thread results
         int   best_slot = -1;
-        for (int i = 0; i < count; ++i) {
-            if (deleted_flags[i]) continue;
-            const float* vec_ptr = _manager->get_float_ptr(i);
-            float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
-            if (dist < min_dist) {
-                min_dist = dist;
-                best_slot = i;
+        float best_dist = 1e9f;
+        for (auto& r : results) {
+            if (r.best_slot != -1 && r.min_dist < best_dist) {
+                best_dist = r.min_dist;
+                best_slot = r.best_slot;
             }
         }
         if (best_slot == -1) return -1;
@@ -172,29 +216,69 @@ namespace CoreEngine {
 
     // -----------------------------------------------------------------------
     std::vector<int> RedBoxVector::search_N(const std::vector<float>& query, int N) {
-        std::priority_queue<std::pair<float, int>> pq;
+        using PQ = std::priority_queue<std::pair<float, int>>;
         int count = static_cast<int>(_manager->get_count());
+        if (count == 0) return {};
 
-        for (int i = 0; i < count; ++i) {
-            if (deleted_flags[i]) continue;
-            const float* vec_ptr = _manager->get_float_ptr(i);
-            float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
-
-            if ((int)pq.size() < N) {
-                pq.push({ dist, i }); // store slot index, resolve to ID after scan
+        // Single-threaded for small DBs
+        if (count < PARALLEL_THRESHOLD || num_threads == 1) {
+            PQ pq;
+            for (int i = 0; i < count; ++i) {
+                if (deleted_flags[i]) continue;
+                const float* vec_ptr = _manager->get_float_ptr(i);
+                float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
+                if ((int)pq.size() < N)              pq.push({ dist, i });
+                else if (dist < pq.top().first) { pq.pop(); pq.push({ dist, i }); }
             }
-            else if (dist < pq.top().first) {
+            std::vector<int> result;
+            result.reserve(pq.size());
+            while (!pq.empty()) {
+                result.push_back(static_cast<int>(_manager->get_id(pq.top().second)));
                 pq.pop();
-                pq.push({ dist, i });
+            }
+            std::reverse(result.begin(), result.end());
+            return result;
+        }
+
+        // Each thread maintains its own local top-N priority queue
+        std::vector<PQ> local_pqs(num_threads);
+
+        auto worker = [&](size_t tid, int start, int end) {
+            PQ& pq = local_pqs[tid];
+            for (int i = start; i < end; ++i) {
+                if (deleted_flags[i]) continue;
+                const float* vec_ptr = _manager->get_float_ptr(i);
+                float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
+                if ((int)pq.size() < N)              pq.push({ dist, i });
+                else if (dist < pq.top().first) { pq.pop(); pq.push({ dist, i }); }
+            }
+        };
+
+        std::vector<std::thread> threads;
+        threads.reserve(num_threads);
+        int slice = count / (int)num_threads;
+        for (size_t t = 0; t < num_threads; ++t) {
+            int start = (int)t * slice;
+            int end   = (t == num_threads - 1) ? count : start + slice;
+            threads.emplace_back(worker, t, start, end);
+        }
+        for (auto& th : threads) th.join();
+
+        // Merge all local top-N queues into one global top-N
+        PQ global_pq;
+        for (auto& pq : local_pqs) {
+            while (!pq.empty()) {
+                auto [dist, slot] = pq.top(); pq.pop();
+                if ((int)global_pq.size() < N)              global_pq.push({ dist, slot });
+                else if (dist < global_pq.top().first) { global_pq.pop(); global_pq.push({ dist, slot }); }
             }
         }
 
         std::vector<int> result;
-        result.reserve(pq.size());
-        while (!pq.empty()) {
-            int slot = pq.top().second;
-            result.push_back(static_cast<int>(_manager->get_id(slot)));
-            pq.pop();
+        result.reserve(global_pq.size());
+        while (!global_pq.empty()) {
+            result.push_back(static_cast<int>(_manager->get_id(global_pq.top().second)));
+            global_pq.pop();
         }
         std::reverse(result.begin(), result.end());
         return result;


### PR DESCRIPTION
The Problem
search() and search_N() were single-threaded. Every query did a linear scan across all 100k vectors on one core, leaving the other 11 cores on (my) machine completely idle during the scan.

The Idea
The search scan is what's called embarrassingly parallel. Each slot is completely independent of every other slot. Computing the L2 distance for slot 47 has zero dependency on slot 46 or slot 48. There's no shared mutable state during the scan. This means you can split the work across threads with no synchronization needed during the scan itself.

How it works for search()
Split the slot range evenly across num_threads threads:
Thread 0: slots 0     to 8332
Thread 1: slots 8333  to 16665
...
Thread 11: slots 91668 to 99999

Each thread scans its own slice independently, tracking its own local_min_dist and local_best_slot on its stack. Stack variables for different threads are in completely separate memory regions,no false sharing, no synchronization needed.

After all threads join, you do one linear pass over num_threads results (12 elements) to find the global winner. That reduction is negligible cost.

How it works for search_N()
ame split, but each thread maintains its own local top-N priority queue of size N. After all threads join, you merge all num_threads priority queues into one global top-N. The merge is at most num_threads * N comparisons — for N=10 and 12 threads that's 120 comparisons, completely negligible.


hardware_concurrency() and the threshold

num_threads is set once at construction via std::thread::hardware_concurrency(), returns the number of logical cores on whatever machine is running, zero overhead at query time, adapts automatically to any hardware.
However, spawning threads on Windows costs roughly 50-200µs per spawn. For small DBs the scan itself is faster than the thread spawn overhead, you'd be spending more time creating threads than doing actual work. So there's a PARALLEL_THRESHOLD = 50000, below this, the single-threaded path is taken. Above it, the parallel path fires. This is why the mixed workload bench (10k vectors) stayed fast, it always hits the single-threaded path.


Why the speedup isn't 12x
Theoretical maximum with 12 threads is 12x. We got roughly 1.64x on search QPS (267 → 439). The gap is explained by
1. Thread spawn cost per query (~600-2400µs for 12 threads on Windows) eating into the scan time
2. All 12 threads are reading from the same 48MB float block simultaneously, competing for the same memory bus. My  Ryzen 5 5500U has a single memory controller shared across all cores, so at some point more threads stops helping and you hit the memory bandwidth ceiling rather than the compute ceiling
3. AVX2 already makes each core very fast at the L2 computation, the single-threaded scan was already well-optimized, leaving less room for threading gains