### PR TITLE
implemented IVF clustering with K-Means++ for sub-millisecond search

### DIFF
--- a/include/redboxdb/SpecificMetadata.hpp
+++ b/include/redboxdb/SpecificMetadata.hpp
@@ -8,10 +8,13 @@ namespace CoreEngine {
         uint64_t dimensions;      // DYNAMIC!
         uint64_t data_type_size;  // 4 (float)
         uint64_t next_id;
-        uint8_t  version;         // Layout version. 0 = legacy interleaved, 1 = columnar
-        uint8_t  _padding[87];    // Future proofing — struct stays 128 bytes
+        uint8_t  version;         // Layout version. 0 = legacy interleaved, 1 = columnar, 2 = clustered
+        uint8_t  num_clusters;    // K
+        uint8_t  is_initialized;  // 0 = K-Means++ not run yet, 1 = ready
+        uint8_t  num_probes;      // M — clusters to search per query
+        uint8_t  _padding[84];    // Future proofing — struct stays 128 bytes
 
-        static constexpr uint8_t CURRENT_VERSION = 1;
+        static constexpr uint8_t CURRENT_VERSION = 2;
     };
 
     static_assert(sizeof(SpecificMetadata) == 128, "SpecificMetadata must be exactly 128 bytes");

--- a/include/redboxdb/cluster_manager.hpp
+++ b/include/redboxdb/cluster_manager.hpp
@@ -1,0 +1,134 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+#include <cmath>
+#include <limits>
+#include <random>
+#include <algorithm>
+#include "redboxdb/distance.hpp"
+
+namespace ClusterManager {
+
+    // Finds the nearest centroid to vec among k centroids.
+    // Returns the cluster index c in [0, k).
+    inline uint16_t find_nearest_centroid(
+        const float* vec,
+        const float* centroid_block,  // K x dim, row-major
+        uint8_t      k,
+        size_t       dim,
+        bool         use_avx2)
+    {
+        float    best_dist = std::numeric_limits<float>::max();
+        uint16_t best_c    = 0;
+        for (uint8_t c = 0; c < k; ++c) {
+            const float* centroid = centroid_block + (size_t)c * dim;
+            float dist = Distance::l2(vec, centroid, dim, use_avx2);
+            if (dist < best_dist) { best_dist = dist; best_c = c; }
+        }
+        return best_c;
+    }
+
+    // Online running-mean update for centroid c.
+    // cluster_count_block[c] must already reflect all vectors assigned so far
+    // (including those assigned during K-Means++ init).
+    inline void update_centroid(
+        float*       centroid_block,
+        uint64_t*    cluster_count_block,
+        uint16_t     c,
+        const float* vec,
+        size_t       dim)
+    {
+        float*   centroid  = centroid_block + (size_t)c * dim;
+        uint64_t new_count = ++cluster_count_block[c];
+        for (size_t d = 0; d < dim; ++d)
+            centroid[d] += (vec[d] - centroid[d]) / (float)new_count;
+    }
+
+    // K-Means++ initialization.
+    // Called once when vector_count reaches the init threshold.
+    // Picks k spread-out centroids from the first n vectors in float_block,
+    // then assigns every one of those n slots to its nearest centroid,
+    // writing into cluster_block and setting cluster_count_block to the
+    // true per-cluster counts so online updates afterwards are correct.
+    inline void kmeans_plus_plus_init(
+        float*        centroid_block,
+        uint64_t*     cluster_count_block,
+        uint16_t*     cluster_block,
+        const float*  float_block,
+        uint8_t       k,
+        size_t        n,           // number of vectors to init from (>= k)
+        size_t        dim,
+        bool          use_avx2)
+    {
+        std::mt19937 rng(42);
+
+        // Reset counts: we will recount from scratch during assignment
+        for (uint8_t c = 0; c < k; ++c) cluster_count_block[c] = 0;
+
+        // Step 1: pick first centroid randomly from the n vectors
+        std::uniform_int_distribution<size_t> uniform(0, n - 1);
+        size_t first = uniform(rng);
+        const float* first_vec = float_block + first * dim;
+        float* c0 = centroid_block;
+        for (size_t d = 0; d < dim; ++d) c0[d] = first_vec[d];
+
+        // Step 2: pick remaining k-1 centroids with D^2 weighting
+        std::vector<float> min_dists(n, std::numeric_limits<float>::max());
+
+        for (uint8_t chosen = 1; chosen < k; ++chosen) {
+            // Update min distances from each point to nearest chosen centroid
+            const float* last_centroid = centroid_block + (size_t)(chosen - 1) * dim;
+            for (size_t i = 0; i < n; ++i) {
+                const float* vec = float_block + i * dim;
+                float d = Distance::l2(vec, last_centroid, dim, use_avx2);
+                if (d < min_dists[i]) min_dists[i] = d;
+            }
+
+            // Sample next centroid proportional to D^2
+            float total = 0.0f;
+            for (float d : min_dists) total += d;
+
+            std::uniform_real_distribution<float> dist_sample(0.0f, total);
+            float  sample     = dist_sample(rng);
+            float  cumulative = 0.0f;
+            size_t next_idx   = 0;
+            for (size_t i = 0; i < n; ++i) {
+                cumulative += min_dists[i];
+                if (cumulative >= sample) { next_idx = i; break; }
+            }
+
+            const float* next_vec     = float_block + next_idx * dim;
+            float*       next_centroid = centroid_block + (size_t)chosen * dim;
+            for (size_t d = 0; d < dim; ++d) next_centroid[d] = next_vec[d];
+        }
+
+        // Step 3: assign all n vectors to their nearest centroid.
+        // Compute true per-cluster means and counts so post-init online
+        // updates use the correct denominator and don't destroy centroids.
+        //
+        // We do two passes:
+        //   Pass 1 — assign cluster_block, accumulate sums + counts
+        //   Pass 2 — divide sums by counts to get true cluster means
+
+        std::vector<std::vector<double>> sums(k, std::vector<double>(dim, 0.0));
+
+        for (size_t i = 0; i < n; ++i) {
+            const float* vec = float_block + i * dim;
+            uint16_t c = find_nearest_centroid(vec, centroid_block, k, dim, use_avx2);
+            cluster_block[i] = c;
+            cluster_count_block[c]++;
+            for (size_t d = 0; d < dim; ++d)
+                sums[c][d] += (double)vec[d];
+        }
+
+        // Recompute centroids as true means of assigned vectors
+        for (uint8_t c = 0; c < k; ++c) {
+            if (cluster_count_block[c] == 0) continue;
+            float* centroid = centroid_block + (size_t)c * dim;
+            double inv = 1.0 / (double)cluster_count_block[c];
+            for (size_t d = 0; d < dim; ++d)
+                centroid[d] = (float)(sums[c][d] * inv);
+        }
+    }
+
+} // namespace ClusterManager

--- a/include/redboxdb/engine.hpp
+++ b/include/redboxdb/engine.hpp
@@ -10,8 +10,11 @@ namespace CoreEngine {
 
     class RedBoxVector {
     private:
-        static constexpr int    default_capacity = 1000;
-        static constexpr size_t TOMBSTONE_COMPACT_SLACK = 64;
+        static constexpr int     default_capacity      = 1000;
+        static constexpr size_t  TOMBSTONE_COMPACT_SLACK = 64;
+        static constexpr int     PARALLEL_THRESHOLD    = 50000;
+        static constexpr uint8_t DEFAULT_CLUSTERS      = 25;
+        static constexpr uint8_t DEFAULT_PROBES        = 1;
 
         size_t dimension;
         std::unique_ptr<StorageManager::Manager> _manager;
@@ -29,13 +32,19 @@ namespace CoreEngine {
 
         std::unordered_map<uint64_t, size_t> id_to_index;
 
+        // In-memory inverted index: cluster_index[c] = list of slot numbers in cluster c.
+        // Built on open from cluster_block, updated on every insert.
+        // Lets search() jump directly to ~1000 candidates without scanning 100k slots.
+        std::vector<std::vector<int>> cluster_index;
+
         bool   use_avx2;
         size_t num_threads;
 
-        static constexpr int PARALLEL_THRESHOLD = 50000;
-
     public:
-        RedBoxVector(std::string file_name, size_t dim, int capacity = default_capacity);
+        RedBoxVector(std::string file_name, size_t dim,
+                     int     capacity   = default_capacity,
+                     uint8_t k          = DEFAULT_CLUSTERS,
+                     uint8_t num_probes = DEFAULT_PROBES);
 
         void     insert(uint64_t id, const std::vector<float>& vec);
         uint64_t insert_auto(const std::vector<float>& vec);
@@ -48,7 +57,6 @@ namespace CoreEngine {
         // Tombstone helpers
         void load_tombstones();
         void append_tombstone(uint64_t id);
-        // Rewrites the .del file to contain only the current live deleted_ids set.
         void compact_tombstones();
 
         // Legacy / status

--- a/include/redboxdb/storage_manager.hpp
+++ b/include/redboxdb/storage_manager.hpp
@@ -19,27 +19,59 @@ namespace StorageManager {
 
         CoreEngine::SpecificMetadata* header;
 
-        // Columnar layout (version 1):
-        //   [ Header (128 bytes) ]
-        //   [ ID block:    capacity * sizeof(uint64_t) ]
-        //   [ Float block: capacity * dimensions * sizeof(float) ]
-        uint64_t* id_block;    // points to start of ID column
-        float*    float_block; // points to start of float column
+        // Clustered columnar layout (version 2):
+        //   [ Header (128 bytes)                        ]
+        //   [ centroid_block:      K x dim x 4 bytes    ]
+        //   [ cluster_count_block: K x 8 bytes          ]
+        //   [ cluster_block:       capacity x 2 bytes   ]
+        //   [ id_block:            capacity x 8 bytes   ]
+        //   [ float_block:         capacity x dim x 4   ]
+        float*    centroid_block;
+        uint64_t* cluster_count_block;
+        uint16_t* cluster_block;
+        uint64_t* id_block;
+        float*    float_block;
 
     public:
-        Manager(const std::string& db_file, uint64_t dimensions, int initial_capacity);
+        Manager(const std::string& db_file, uint64_t dimensions, int initial_capacity, uint8_t num_clusters = 100, uint8_t num_probes = 1);
         ~Manager();
 
-        void             add_vector(uint64_t id, const std::vector<float>& vec);
+        void             add_vector(uint64_t id, const std::vector<float>& vec, uint16_t cluster);
         const float*     get_float_ptr(int index) const;
         float*           get_float_ptr_mut(int index);
         uint64_t         get_id(int index) const;
+        uint16_t         get_cluster(int index) const;
+        void             set_cluster(int index, uint16_t c);
         uint64_t         get_count() const;
         uint64_t         next_id();
+
+        float*       get_centroid_block()       { return centroid_block; }
+        uint64_t*    get_cluster_count_block()  { return cluster_count_block; }
+        uint16_t*    get_cluster_block()        { return cluster_block; }
+
+        bool    is_cluster_initialized() const  { return header->is_initialized != 0; }
+        void    set_cluster_initialized()       { header->is_initialized = 1; }
+        uint8_t get_num_clusters() const        { return header->num_clusters; }
+        uint8_t get_num_probes()   const        { return header->num_probes; }
     };
 }
 
 
+/*
+    Clustered columnar layout (version 2):
+
+    [ Header (128 bytes)                      ]
+    [ centroid_block: K x dim x 4 bytes       ]  <- K centroids, row-major
+    [ cluster_count_block: K x 8 bytes        ]  <- vector count per cluster
+    [ cluster_block: capacity x uint16_t      ]  <- which cluster each slot belongs to
+    [ id_block: capacity x uint64_t           ]
+    [ float_block: capacity x dim x float     ]
+
+    Slot i:
+      cluster_block[i]             -> cluster assignment
+      id_block[i]                  -> vector's user-facing ID
+      float_block + i * dimensions -> pointer to float data
+*/
 /*
     I am on windows! Forgive me.
 */

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -9,52 +9,105 @@
 #include <algorithm>
 #include "redboxdb/cpu_features.hpp"
 #include "redboxdb/distance.hpp"
+#include "redboxdb/cluster_manager.hpp"
 #include <cstring>
 
 
 namespace CoreEngine {
 
-    RedBoxVector::RedBoxVector(std::string file_name, size_t dim, int capacity): dimension(dim), file_name(file_name), tombstone_file(file_name + ".del")
+    RedBoxVector::RedBoxVector(std::string file_name, size_t dim, int capacity, uint8_t k, uint8_t num_probes) : dimension(dim), file_name(file_name), tombstone_file(file_name + ".del")
     {
-        _manager = std::make_unique<StorageManager::Manager>(file_name, dim, capacity);
+        _manager = std::make_unique<StorageManager::Manager>(file_name, dim, capacity, k, num_probes);
         load_tombstones();
-
-        // Build ID→index and deleted_flags from existing file contents
-        int existing = static_cast<int>(_manager->get_count());
-        deleted_flags.resize(existing, 0);
-        for (int i = 0; i < existing; ++i) {
-            uint64_t id = _manager->get_id(i);
-            if (deleted_ids.count(id))
-                deleted_flags[i] = 1;
-            else
-                id_to_index[id] = i;
-        }
 
         use_avx2    = Platform::has_avx2();
         num_threads = std::max(1u, std::thread::hardware_concurrency());
+
+        // Build ID->index, deleted_flags, and cluster_index from existing file contents
+        int existing = static_cast<int>(_manager->get_count());
+        deleted_flags.resize(existing, 0);
+        cluster_index.resize(k);
+
+        for (int i = 0; i < existing; ++i) {
+            uint64_t id = _manager->get_id(i);
+            if (deleted_ids.count(id)) {
+                deleted_flags[i] = 1;
+            } else {
+                id_to_index[id] = i;
+                // Rebuild in-memory cluster index from mmap cluster_block
+                if (_manager->is_cluster_initialized()) {
+                    uint16_t c = _manager->get_cluster(i);
+                    if (c < k) cluster_index[c].push_back(i);
+                }
+            }
+        }
+
+        if (_manager->is_cluster_initialized()) {
+            size_t max_cluster = 0;
+            for (auto& v : cluster_index) max_cluster = std::max(max_cluster, v.size());
+            std::cout << "[DB] Max cluster size: " << max_cluster << "\n";
+        }
+
         std::cout << "[DB] AVX2: " << (use_avx2 ? "enabled" : "disabled")
-                  << " | Threads: " << num_threads << "\n";
+                  << " | Threads: " << num_threads
+                  << " | Clusters: " << static_cast<int>(_manager->get_num_clusters())
+                  << " | Probes: "   << static_cast<int>(_manager->get_num_probes()) << "\n";
     }
 
     // -----------------------------------------------------------------------
     void RedBoxVector::insert(uint64_t id, const std::vector<float>& vec) {
         if (deleted_ids.count(id)) {
-            // Clear the old slot's flag — it stays in the mmap as a zombie,
-            // but we don't want it showing up as deleted in scans anymore.
-            auto old_it = id_to_index.find(id); // not present (erased on remove)
-            // old slot flag: we don't have the index anymore, so we can't clear it.
-            // It will be skipped correctly: the new append below gets flag=0,
-            // and the old zombie slot has no entry in id_to_index so update()
-            // won't touch it. The flag on the old slot stays 1 (correct — it IS
-            // a dead row). The new row gets flag=0.
-            (void)old_it;
             deleted_ids.erase(id);
         }
         try {
-            size_t new_index = _manager->get_count();
-            _manager->add_vector(id, vec);
-            id_to_index[id] = new_index;
-            deleted_flags.push_back(0); // new slot is live
+            uint8_t  k    = _manager->get_num_clusters();
+            size_t   slot = _manager->get_count();
+            uint16_t c    = 0;
+
+            if (!_manager->is_cluster_initialized()) {
+                // Pre-initialization: assign to cluster 0
+                c = 0;
+                _manager->add_vector(id, vec, c);
+
+                if ((uint64_t)(slot + 1) >= 10000) {
+                    // Hit K vectors — run K-Means++ and assign all slots
+                    ClusterManager::kmeans_plus_plus_init(
+                        _manager->get_centroid_block(),
+                        _manager->get_cluster_count_block(),
+                        _manager->get_cluster_block(),
+                        _manager->get_float_ptr(0),
+                        k, slot+1, dimension, use_avx2);
+                    _manager->set_cluster_initialized();
+
+                    // Rebuild cluster_index from scratch now that assignments are real
+                    for (auto& v : cluster_index) v.clear();
+                    for (int i = 0; i <= (int)slot; ++i) {
+                        if (!deleted_flags[i]) {
+                            uint16_t ci = _manager->get_cluster(i);
+                            if (ci < k) cluster_index[ci].push_back(i);
+                        }
+                    }
+
+                    std::cout << "[DB] K-Means++ initialized with K=" << (int)k << "\n";
+                }
+            } else {
+                // Normal path: find nearest centroid, assign, update centroid online
+                c = ClusterManager::find_nearest_centroid(
+                    vec.data(),
+                    _manager->get_centroid_block(),
+                    k, dimension, use_avx2);
+                _manager->add_vector(id, vec, c);
+                ClusterManager::update_centroid(
+                    _manager->get_centroid_block(),
+                    _manager->get_cluster_count_block(),
+                    c, vec.data(), dimension);
+
+                // Update in-memory inverted index
+                cluster_index[c].push_back(static_cast<int>(slot));
+            }
+
+            id_to_index[id] = slot;
+            deleted_flags.push_back(0);
         }
         catch (const std::exception& e) {
             std::cerr << "Insert Error: " << e.what() << "\n";
@@ -81,63 +134,124 @@ namespace CoreEngine {
         int count = static_cast<int>(_manager->get_count());
         if (count == 0) return -1;
 
-        // Single-threaded for small DBs — thread overhead not worth it
-        if (count < PARALLEL_THRESHOLD || num_threads == 1) {
-            float min_dist = 1e9f;
-            int   best_slot = -1;
-            for (int i = 0; i < count; ++i) {
-                if (deleted_flags[i]) continue;
-                const float* vec_ptr = _manager->get_float_ptr(i);
-                float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
-                if (dist < min_dist) { min_dist = dist; best_slot = i; }
+        uint8_t k           = _manager->get_num_clusters();
+        uint8_t num_probes  = _manager->get_num_probes();
+        bool    initialized = _manager->is_cluster_initialized();
+
+        // --- Build candidate list ---
+        // If initialized: O(K) centroid scan + O(cluster_size) lookup via cluster_index
+        // If not: full slot list (pre-init fallback)
+        std::vector<int> candidates;
+
+        if (initialized) {
+            const float* centroid_block = _manager->get_centroid_block();
+
+            // Score all K centroids, pick nearest num_probes
+            std::vector<std::pair<float, uint16_t>> centroid_dists(k);
+            for (uint8_t c = 0; c < k; ++c) {
+                float d = Distance::l2(query.data(), centroid_block + (size_t)c * dimension,
+                                       dimension, use_avx2);
+                centroid_dists[c] = { d, c };
             }
-            if (best_slot == -1) return -1;
-            return static_cast<int>(_manager->get_id(best_slot));
+            std::partial_sort(centroid_dists.begin(),
+                              centroid_dists.begin() + num_probes,
+                              centroid_dists.end());
+
+            // Collect candidates directly from inverted index — no full scan
+            size_t reserve_size = 0;
+            for (int p = 0; p < num_probes; ++p)
+                reserve_size += cluster_index[centroid_dists[p].second].size();
+            candidates.reserve(reserve_size);
+
+            for (int p = 0; p < num_probes; ++p) {
+                uint16_t c = centroid_dists[p].second;
+                for (int slot : cluster_index[c])
+                    if (!deleted_flags[slot]) candidates.push_back(slot);
+            }
+        } else {
+            candidates.reserve(count);
+            for (int i = 0; i < count; ++i)
+                if (!deleted_flags[i]) candidates.push_back(i);
         }
 
-        // Parallel scan — each thread scans its own slice, writes to its own slot
-        // in these arrays (no false sharing between threads, each index is independent)
-        struct ThreadResult { float min_dist; int best_slot; };
-        std::vector<ThreadResult> results(num_threads, { 1e9f, -1 });
+        if (candidates.empty()) return -1;
 
-        auto worker = [&](size_t tid, int start, int end) {
-            float local_min  = 1e9f;
-            int   local_best = -1;
-            for (int i = start; i < end; ++i) {
-                if (deleted_flags[i]) continue;
-                const float* vec_ptr = _manager->get_float_ptr(i);
-                float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
-                if (dist < local_min) { local_min = dist; local_best = i; }
-            }
-            results[tid] = { local_min, local_best };
-        };
-
-        // Divide slots as evenly as possible across threads
-        std::vector<std::thread> threads;
-        threads.reserve(num_threads);
-        int slice = count / (int)num_threads;
-        for (size_t t = 0; t < num_threads; ++t) {
-            int start = (int)t * slice;
-            int end   = (t == num_threads - 1) ? count : start + slice;
-            threads.emplace_back(worker, t, start, end);
-        }
-        for (auto& th : threads) th.join();
-
-        // Reduce: find global winner across all thread results
+        // --- Distance scan over candidates only ---
+        float min_dist  = 1e9f;
         int   best_slot = -1;
-        float best_dist = 1e9f;
-        for (auto& r : results) {
-            if (r.best_slot != -1 && r.min_dist < best_dist) {
-                best_dist = r.min_dist;
-                best_slot = r.best_slot;
-            }
+        for (int i : candidates) {
+            const float* vec_ptr = _manager->get_float_ptr(i);
+            float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
+            if (dist < min_dist) { min_dist = dist; best_slot = i; }
         }
+
         if (best_slot == -1) return -1;
         return static_cast<int>(_manager->get_id(best_slot));
     }
 
     // -----------------------------------------------------------------------
-    // Tombstone helpers
+    std::vector<int> RedBoxVector::search_N(const std::vector<float>& query, int N) {
+        using PQ = std::priority_queue<std::pair<float, int>>;
+        int count = static_cast<int>(_manager->get_count());
+        if (count == 0) return {};
+
+        uint8_t k           = _manager->get_num_clusters();
+        uint8_t num_probes  = _manager->get_num_probes();
+        bool    initialized = _manager->is_cluster_initialized();
+
+        // --- Build candidate list ---
+        std::vector<int> candidates;
+
+        if (initialized) {
+            const float* centroid_block = _manager->get_centroid_block();
+
+            std::vector<std::pair<float, uint16_t>> centroid_dists(k);
+            for (uint8_t c = 0; c < k; ++c) {
+                float d = Distance::l2(query.data(), centroid_block + (size_t)c * dimension,
+                                       dimension, use_avx2);
+                centroid_dists[c] = { d, c };
+            }
+            std::partial_sort(centroid_dists.begin(),
+                              centroid_dists.begin() + num_probes,
+                              centroid_dists.end());
+
+            size_t reserve_size = 0;
+            for (int p = 0; p < num_probes; ++p)
+                reserve_size += cluster_index[centroid_dists[p].second].size();
+            candidates.reserve(reserve_size);
+
+            for (int p = 0; p < num_probes; ++p) {
+                uint16_t c = centroid_dists[p].second;
+                for (int slot : cluster_index[c])
+                    if (!deleted_flags[slot]) candidates.push_back(slot);
+            }
+        } else {
+            candidates.reserve(count);
+            for (int i = 0; i < count; ++i)
+                if (!deleted_flags[i]) candidates.push_back(i);
+        }
+
+        if (candidates.empty()) return {};
+
+        // --- Distance scan over candidates only ---
+        PQ pq;
+        for (int i : candidates) {
+            const float* vec_ptr = _manager->get_float_ptr(i);
+            float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
+            if ((int)pq.size() < N)                    pq.push({ dist, i });
+            else if (dist < pq.top().first) { pq.pop(); pq.push({ dist, i }); }
+        }
+
+        std::vector<int> result;
+        result.reserve(pq.size());
+        while (!pq.empty()) {
+            result.push_back(static_cast<int>(_manager->get_id(pq.top().second)));
+            pq.pop();
+        }
+        std::reverse(result.begin(), result.end());
+        return result;
+    }
+
     // -----------------------------------------------------------------------
     void RedBoxVector::load_tombstones() {
         std::ifstream f(tombstone_file, std::ios::binary);
@@ -158,15 +272,8 @@ namespace CoreEngine {
         }
     }
 
-    // Rewrites the .del file so it contains exactly one entry per live
-    // deleted ID — no duplicates, no stale re-inserted IDs.
-    //
-    // Called automatically from remove() when the file has accumulated
-    // TOMBSTONE_COMPACT_SLACK extra entries beyond the live set size.
     void RedBoxVector::compact_tombstones() {
-        // Truncate-and-rewrite (atomic-ish: write to .tmp, then rename)
         std::string tmp_file = tombstone_file + ".tmp";
-
         {
             std::ofstream f(tmp_file, std::ios::binary | std::ios::trunc);
             if (!f.is_open()) {
@@ -176,9 +283,8 @@ namespace CoreEngine {
             for (uint64_t id : deleted_ids) {
                 f.write(reinterpret_cast<const char*>(&id), sizeof(id));
             }
-        } // f is flushed & closed here
+        }
 
-        // Replace old file
         if (std::filesystem::exists(tombstone_file)) {
             std::filesystem::remove(tombstone_file);
         }
@@ -197,10 +303,11 @@ namespace CoreEngine {
     bool RedBoxVector::remove(uint64_t id) {
         if (deleted_ids.count(id)) return false;
 
-        // Mark the slot as deleted in the hot-path array before erasing from index
         auto it = id_to_index.find(id);
         if (it != id_to_index.end()) {
             deleted_flags[it->second] = 1;
+            // Note: we don't remove from cluster_index — deleted_flags check handles it.
+            // cluster_index entries for deleted slots are simply skipped during search.
             id_to_index.erase(it);
         }
 
@@ -212,76 +319,6 @@ namespace CoreEngine {
         }
 
         return true;
-    }
-
-    // -----------------------------------------------------------------------
-    std::vector<int> RedBoxVector::search_N(const std::vector<float>& query, int N) {
-        using PQ = std::priority_queue<std::pair<float, int>>;
-        int count = static_cast<int>(_manager->get_count());
-        if (count == 0) return {};
-
-        // Single-threaded for small DBs
-        if (count < PARALLEL_THRESHOLD || num_threads == 1) {
-            PQ pq;
-            for (int i = 0; i < count; ++i) {
-                if (deleted_flags[i]) continue;
-                const float* vec_ptr = _manager->get_float_ptr(i);
-                float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
-                if ((int)pq.size() < N)              pq.push({ dist, i });
-                else if (dist < pq.top().first) { pq.pop(); pq.push({ dist, i }); }
-            }
-            std::vector<int> result;
-            result.reserve(pq.size());
-            while (!pq.empty()) {
-                result.push_back(static_cast<int>(_manager->get_id(pq.top().second)));
-                pq.pop();
-            }
-            std::reverse(result.begin(), result.end());
-            return result;
-        }
-
-        // Each thread maintains its own local top-N priority queue
-        std::vector<PQ> local_pqs(num_threads);
-
-        auto worker = [&](size_t tid, int start, int end) {
-            PQ& pq = local_pqs[tid];
-            for (int i = start; i < end; ++i) {
-                if (deleted_flags[i]) continue;
-                const float* vec_ptr = _manager->get_float_ptr(i);
-                float dist = Distance::l2(vec_ptr, query.data(), dimension, use_avx2);
-                if ((int)pq.size() < N)              pq.push({ dist, i });
-                else if (dist < pq.top().first) { pq.pop(); pq.push({ dist, i }); }
-            }
-        };
-
-        std::vector<std::thread> threads;
-        threads.reserve(num_threads);
-        int slice = count / (int)num_threads;
-        for (size_t t = 0; t < num_threads; ++t) {
-            int start = (int)t * slice;
-            int end   = (t == num_threads - 1) ? count : start + slice;
-            threads.emplace_back(worker, t, start, end);
-        }
-        for (auto& th : threads) th.join();
-
-        // Merge all local top-N queues into one global top-N
-        PQ global_pq;
-        for (auto& pq : local_pqs) {
-            while (!pq.empty()) {
-                auto [dist, slot] = pq.top(); pq.pop();
-                if ((int)global_pq.size() < N)              global_pq.push({ dist, slot });
-                else if (dist < global_pq.top().first) { global_pq.pop(); global_pq.push({ dist, slot }); }
-            }
-        }
-
-        std::vector<int> result;
-        result.reserve(global_pq.size());
-        while (!global_pq.empty()) {
-            result.push_back(static_cast<int>(_manager->get_id(global_pq.top().second)));
-            global_pq.pop();
-        }
-        std::reverse(result.begin(), result.end());
-        return result;
     }
 
     // -----------------------------------------------------------------------
@@ -304,24 +341,36 @@ namespace CoreEngine {
 
 
 // ============================================================
-// StorageManager — Columnar layout (version 1)
+// StorageManager — Clustered columnar layout (version 2)
 // ============================================================
 namespace StorageManager {
 
-    // Helper: set up id_block and float_block pointers from map_base
-    static void setup_pointers(void* map_base, uint64_t capacity,
-                                CoreEngine::SpecificMetadata*& header,
-                                uint64_t*& id_block, float*& float_block)
+    static void setup_pointers(
+        void*     map_base,
+        uint64_t  capacity,
+        uint8_t   k,
+        uint64_t  dim,
+        CoreEngine::SpecificMetadata*& header,
+        float*&    centroid_block,
+        uint64_t*& cluster_count_block,
+        uint16_t*& cluster_block,
+        uint64_t*& id_block,
+        float*&    float_block)
     {
-        header      = (CoreEngine::SpecificMetadata*)map_base;
-        id_block    = (uint64_t*)((char*)map_base + sizeof(CoreEngine::SpecificMetadata));
-        float_block = (float*)((char*)id_block + capacity * sizeof(uint64_t));
+        header              = (CoreEngine::SpecificMetadata*)map_base;
+        centroid_block      = (float*)((char*)map_base + sizeof(CoreEngine::SpecificMetadata));
+        cluster_count_block = (uint64_t*)(centroid_block + (size_t)k * dim);
+        cluster_block       = (uint16_t*)(cluster_count_block + k);
+        id_block            = (uint64_t*)(cluster_block + capacity);
+        float_block         = (float*)(id_block + capacity);
     }
 
-    Manager::Manager(const std::string& db_file, size_t dimensions, int initial_capacity)
+    Manager::Manager(const std::string& db_file, uint64_t dimensions,
+                     int initial_capacity, uint8_t num_clusters, uint8_t num_probes)
         : allocated_size(initial_capacity), filename(db_file),
           hFile(NULL), hMapFile(NULL), map_base(nullptr),
-          header(nullptr), id_block(nullptr), float_block(nullptr)
+          header(nullptr), centroid_block(nullptr), cluster_count_block(nullptr),
+          cluster_block(nullptr), id_block(nullptr), float_block(nullptr)
     {
         hFile = CreateFileA(filename.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL,
             OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -331,12 +380,14 @@ namespace StorageManager {
         GetFileSizeEx(hFile, &fileSize);
         size_t current_size = (size_t)fileSize.QuadPart;
 
-        // Columnar layout size:
-        //   header + (capacity * 8) + (capacity * dim * 4)
-        size_t id_block_bytes    = (size_t)initial_capacity * sizeof(uint64_t);
-        size_t float_block_bytes = (size_t)initial_capacity * dimensions * sizeof(float);
-        size_t required_size     = sizeof(CoreEngine::SpecificMetadata)
-                                 + id_block_bytes + float_block_bytes;
+        size_t centroid_bytes      = (size_t)num_clusters * dimensions * sizeof(float);
+        size_t cluster_count_bytes = (size_t)num_clusters * sizeof(uint64_t);
+        size_t cluster_block_bytes = (size_t)initial_capacity * sizeof(uint16_t);
+        size_t id_block_bytes      = (size_t)initial_capacity * sizeof(uint64_t);
+        size_t float_block_bytes   = (size_t)initial_capacity * dimensions * sizeof(float);
+        size_t required_size       = sizeof(CoreEngine::SpecificMetadata)
+                                   + centroid_bytes + cluster_count_bytes
+                                   + cluster_block_bytes + id_block_bytes + float_block_bytes;
 
         if (current_size == 0) {
             LARGE_INTEGER distance;
@@ -352,7 +403,9 @@ namespace StorageManager {
         map_base = MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, 0);
         if (!map_base) throw std::runtime_error("MapViewOfFile failed");
 
-        setup_pointers(map_base, (uint64_t)initial_capacity, header, id_block, float_block);
+        setup_pointers(map_base, (uint64_t)initial_capacity, num_clusters, dimensions,
+                       header, centroid_block, cluster_count_block,
+                       cluster_block, id_block, float_block);
 
         if (current_size == 0) {
             header->vector_count   = 0;
@@ -361,6 +414,9 @@ namespace StorageManager {
             header->data_type_size = sizeof(float);
             header->next_id        = 1;
             header->version        = CoreEngine::SpecificMetadata::CURRENT_VERSION;
+            header->num_clusters   = num_clusters;
+            header->is_initialized = 0;
+            header->num_probes     = num_probes;
         }
         else {
             if (header->version != CoreEngine::SpecificMetadata::CURRENT_VERSION) {
@@ -379,10 +435,6 @@ namespace StorageManager {
     }
 
     uint64_t Manager::next_id() { return header->next_id++; }
-    // SO अहीले लाइ, we are just incremeting the id
-    // but what happens if a vector is deleted? नसोध मलाइ
-    // so definately need a way to get id's any other way then incrementing from a base value!
-    // maybe look for deleted id's first? idk फ्युचर मी पर्रोबल्म
 
     Manager::~Manager() {
         if (map_base) { FlushViewOfFile(map_base, 0); UnmapViewOfFile(map_base); }
@@ -390,35 +442,43 @@ namespace StorageManager {
         if (hFile != INVALID_HANDLE_VALUE) CloseHandle(hFile);
     }
 
-    void Manager::add_vector(uint64_t id, const std::vector<float>& vec) {
+    void Manager::add_vector(uint64_t id, const std::vector<float>& vec, uint16_t cluster) {
         if (vec.size() != header->dimensions)
             throw std::invalid_argument("Vector dimension mismatch");
         if (header->vector_count >= header->max_capacity)
             throw std::runtime_error("Database full");
 
         size_t slot = header->vector_count;
-        id_block[slot] = id;
+        cluster_block[slot] = cluster;
+        id_block[slot]      = id;
         float* dst = float_block + slot * header->dimensions;
         std::memcpy(dst, vec.data(), header->dimensions * sizeof(float));
         header->vector_count++;
     }
 
     const float* Manager::get_float_ptr(int index) const {
-        if (index >= (int)header->vector_count)
-            throw std::out_of_range("Index out of bounds");
+        if (index >= (int)header->vector_count) throw std::out_of_range("Index out of bounds");
         return float_block + (size_t)index * header->dimensions;
     }
 
     float* Manager::get_float_ptr_mut(int index) {
-        if (index >= (int)header->vector_count)
-            throw std::out_of_range("Index out of bounds");
+        if (index >= (int)header->vector_count) throw std::out_of_range("Index out of bounds");
         return float_block + (size_t)index * header->dimensions;
     }
 
     uint64_t Manager::get_id(int index) const {
-        if (index >= (int)header->vector_count)
-            throw std::out_of_range("Index out of bounds");
+        if (index >= (int)header->vector_count) throw std::out_of_range("Index out of bounds");
         return id_block[index];
+    }
+
+    uint16_t Manager::get_cluster(int index) const {
+        if (index >= (int)header->vector_count) throw std::out_of_range("Index out of bounds");
+        return cluster_block[index];
+    }
+
+    void Manager::set_cluster(int index, uint16_t c) {
+        if (index >= (int)header->vector_count) throw std::out_of_range("Index out of bounds");
+        cluster_block[index] = c;
     }
 
     uint64_t Manager::get_count() const { return header->vector_count; }


### PR DESCRIPTION
OHhhhhhhhhhhhhhh boy here we go

Issue was:
Brute-force linear scan with current benchmark config gave P50=2.26ms, P99=3.24ms, QPS=431. The bottleneck was scanning all 100k float vectors per query : O(N×dim) distance computations regardless of query location.

Approach: K-Means Approximate Nearest Neighbor
The goal is to reduce per-query scan work from O(N) to O(K + N/K) by partitioning the vector space into K clusters, each with a centroid. At query time, find the nearest centroid in O(K), then scan only that cluster's ~N/K vectors. Sounds simple enough huh!

Data Structures
In mmap (persistent):
centroid_block -> Centroid c starts at centroid_block + c * dim. So centroid 1 starts at index 4. Row-major = each centroid's floats are contiguous
you can pass centroid_block + c * dim directly to the L2 function.

cluster_count_block -> K uint64_ts, one per centroid, tracking how many vectors are currently assigned to that cluster. Used exclusively by the online mean update formula.
cluster_count_block[0] = 312    ← 312 vectors assigned to centroid 0
cluster_count_block[1] = 487
cluster_count_block[2] = 201

cluster_block->One uint16_t per slot, parallel to id_block and float_block. Slot i across all three arrays refers to the same vector.

We are bascially using the same ideas as that of the id block!

slot:                0      1      2      3      4      5
cluster_block: 2      0      1      1      2      0
id_block:         9001   9002   9003   9004   9005   9006
float_block:     [...] [...] [...] [...] [...] [...]


In memory (non-persistant)
cluster_index->The in-memory inverted view of cluster_block. Built by scanning cluster_block once on open

cluster_index[0] = {1, 5}        ← slots where cluster_block[i] == 0
cluster_index[1] = {2, 3}        ← slots where cluster_block[i] == 1
cluster_index[2] = {0, 4}        ← slots where cluster_block[i] == 2


SpecificMetadata fields
num_clusters  = 25    ← K, fixed at DB creation
num_probes    = 1     ← how many clusters to search per query
is_initialized = 1   ← 0 until K-Means++ has run, then permanently 1



Initialization: K-Means++
Triggered once when vector_count reaches a threshold (50000). It literally does NOTHING right now, as we simply cant reach that value with our benchmarking but future proffing is good


1. Pick first centroid uniformly at random from the N vectors
2. For each subsequent centroid c=1..K-1: compute each vector's distance to the nearest already-chosen centroid, sample the next centroid with probability proportional to D² — this maximizes spread
3. Two-pass assignment: assign all N vectors to their nearest centroid accumulating per-cluster float sums and counts, then recompute each centroid as the true mean of its assigned vectors

The two-pass approach is critical. The original implementation used an online running mean during assignment, which left cluster_count_block reflecting only the K init vectors. Post-init inserts then used a denominator of 1-3, which destroyed the centroids — all 99,900 subsequent vectors collapsed into one cluster (verified: max cluster size = 99,900).

The fix: accumulate sums in double precision, divide once. cluster_count_block[c] is set to the true count of assigned vectors. Post-init online updates then use the correct denominator and centroids remain stable.


Insert Path (post-init)
1. find_nearest_centroid: score all K centroids with AVX2 L2, return argmin, O(K×dim)
2. Write cluster assignment to cluster_block[slot]
3. Online centroid update: centroid[c] += (vec - centroid[c]) / ++cluster_count_block[c] — exact running mean, O(dim)
4. Append slot to cluster_index[c]

Search Path
1. Score all K centroids against query, O(K×dim)
2. partial_sort to find nearest num_probes centroids
3. Collect candidate slots directly from cluster_index[c], O(cluster_size), no full scan
4. Run AVX2 L2 distance on candidates only, O(cluster_size × dim)


The previous broken attempt built the candidate list by iterating all N slots and checking cluster_block[i], O(N) with a cheap comparison, but still touching 100k memory locations per query. That gave the same latency as brute force. The inverted index eliminates that scan entirely.

Results at K=100

Metric | Before | After | Delta
Search P50 | 2.26ms | 0.10ms | -95%
Search P99 | 3.24ms | 0.44ms | -86%
QPS | 431 | 8,514 | +19.7x
Insert throughput | 1.6M/s | 277k/s | -83%

The insert regression is from the O(K×dim) centroid scan per insert, measured at 2,176ns average, capping theoretical insert throughput at 459k/s. Reducing to K=10 recovers insert throughput to 1.07M/s at the cost of search P50 degrading to 0.84ms.
