### PR TITLE
Fix ConcurrentReadsAndWritesDoNotCrash CI failure

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -531,9 +531,12 @@ TEST_F(ConcurrentAccessTest, ConcurrentReadsAndWritesDoNotCrash) {
     std::thread writer([&]() {
         int id = INITIAL + 1;
         while (!stop.load()) {
-            std::lock_guard<std::mutex> lk(db_mutex);
-            db.insert((uint64_t)id, { (float)id, 0.0f, 0.0f });
-            ++id;
+            {
+                std::lock_guard<std::mutex> lk(db_mutex);
+                db.insert((uint64_t)id, { (float)id, 0.0f, 0.0f });
+                ++id;
+            }
+            std::this_thread::yield();
         }
         });
 


### PR DESCRIPTION
Writer thread was tight-looping on insert() with no yield, hogging the mutex and starving readers on slower CI machines (4-core MinGW). Release the lock and yield between iterations so readers get a fair chance.