### PR TITLE
Guard AVX2 intrinsics and compiler flags for non-x86 builds

### DIFF
--- a/include/redboxdb/cpu_features.hpp
+++ b/include/redboxdb/cpu_features.hpp
@@ -4,14 +4,17 @@
 // I might answer
 // I am poor and my ryzen 5 5500U doesn't support AVX-512, but it does in fact support AVX2.
 
-#ifdef _MSC_VER
-    #include <intrin.h>
-#else
-    #include <cpuid.h>
+#if defined(__x86_64__) || defined(_M_X64)
+    #ifdef _MSC_VER
+        #include <intrin.h>
+    #else
+        #include <cpuid.h>
+    #endif
 #endif
 
 namespace Platform {
     inline bool has_avx2() {
+#if defined(__x86_64__) || defined(_M_X64)
 #ifdef _MSC_VER
         int info[4] = { 0, 0, 0, 0 };
         __cpuid(info, 0);           // First ask: what's the max input level?
@@ -26,6 +29,10 @@ namespace Platform {
 
         __cpuid_count(7, 0, eax, ebx, ecx, edx);
         return (ebx & (1 << 5)) != 0; // Bit 5 of EBX = AVX2
+#endif
+#else
+        // No x86 AVX2 support on this architecture (e.g. ARM/NEON).
+        return false;
 #endif
     }
 }

--- a/include/redboxdb/distance.hpp
+++ b/include/redboxdb/distance.hpp
@@ -1,6 +1,12 @@
 ﻿#pragma once
-#include <immintrin.h>
 #include <cstddef>
+
+#if defined(__x86_64__) || defined(_M_X64)
+    #define REDBOXDB_HAS_AVX2_INTRINSICS 1
+    #include <immintrin.h>
+#else
+    #define REDBOXDB_HAS_AVX2_INTRINSICS 0
+#endif
 
 namespace Distance {
 
@@ -14,6 +20,7 @@ namespace Distance {
         return sum;
     }
 
+#if REDBOXDB_HAS_AVX2_INTRINSICS
     // l2 with avx2
     inline float l2_avx2(const float* a, const float* b, size_t dim) {
         __m256 sum = _mm256_setzero_ps();   // 8-lane accumulator, starts at 0
@@ -64,10 +71,13 @@ namespace Distance {
 
         return result;
     }
+#endif
 
     // Call this everywhere — it picks the right path at runtime
     inline float l2(const float* a, const float* b, size_t dim, bool use_avx2) {
+#if REDBOXDB_HAS_AVX2_INTRINSICS
         if (use_avx2) return l2_avx2(a, b, dim);
+#endif
         return l2_scalar(a, b, dim);
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,11 +15,22 @@ target_include_directories(RedBoxDbLib
 
 target_link_libraries(RedBoxDbLib PRIVATE spdlog::spdlog Threads::Threads)
 
+include(CheckCXXCompilerFlag)
+
 if(MSVC)
-    target_compile_options(RedBoxDbLib PRIVATE /arch:AVX2)
+    check_cxx_compiler_flag("/arch:AVX2" REDBOXDB_HAS_AVX2_FLAG)
+    if(REDBOXDB_HAS_AVX2_FLAG)
+        target_compile_options(RedBoxDbLib PRIVATE /arch:AVX2)
+    endif()
 else()
-    target_compile_options(RedBoxDbLib PRIVATE -mavx2 -mfma)
+    check_cxx_compiler_flag("-mavx2 -mfma" REDBOXDB_HAS_AVX2_FLAG)
+    if(REDBOXDB_HAS_AVX2_FLAG)
+        target_compile_options(RedBoxDbLib PRIVATE -mavx2 -mfma)
+    endif()
 endif()
+# On non-x86 targets (ARM, RISC-V, ...) these flags are invalid and the
+# compiler-flag check above fails, so the library falls back to
+# Distance::l2_scalar() at runtime via Platform::has_avx2() returning false.
 
 set_project_warnings(RedBoxDbLib)
 


### PR DESCRIPTION
## Summary
- `distance.hpp` only includes `<immintrin.h>` and compiles `l2_avx2()` when targeting x86_64; `l2()` falls back to `l2_scalar()` otherwise.
- `cpu_features.hpp` only includes `<cpuid.h>`/`<intrin.h>` and uses CPUID-based detection on x86_64; `Platform::has_avx2()` returns `false` on other architectures. This file wasn't named in either issue, but has the same root cause — it unconditionally included an x86-only header, which would still break ARM builds even with the other two fixes applied.
- `src/CMakeLists.txt` uses `check_cxx_compiler_flag()` to only add `-mavx2 -mfma` (or `/arch:AVX2` on MSVC) when the compiler actually supports them, instead of unconditionally.

## How I tested this
- Ran the actual CMake configure step on this arm64 machine: `REDBOXDB_HAS_AVX2_FLAG` correctly evaluates to `Failed` and the AVX2 flags are skipped. Before this change, configuring already failed outright on this target.
- Confirmed no other code references `l2_avx2` or AVX2 intrinsics directly outside these two files (`hnsw_manager.hpp`'s `<intrin.h>` reference is a false positive — it's already correctly guarded behind `#ifdef _MSC_VER` with a portable `__builtin_prefetch` fallback).
- Full build (spdlog/googletest via FetchContent) couldn't be completed locally due to an unrelated broken libc++ installation in this environment's Command Line Tools (missing `<atomic>`/`<mutex>`/etc. for *any* C++ project on this machine, not specific to this change) — verified the remaining logic by careful review instead.

## Related issues
Closes #96
Closes #97