### PR TITLE
fix: push benchmark report commit back to master

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Run benchmarks (push to main)
         if: github.event_name == 'push'
-        run: python3 benchmark/ci_bench.py commit
+        run: |
+          python3 benchmark/ci_bench.py commit
+          git push origin master
 
       - name: Run benchmarks and post comment (PR)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
ci_bench.py commits the report but the workflow never pushed it back. Added git push to the workflow step.