### PR TITLE
fix: send error response for unknown commands, prevent protocol desyn…

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -323,6 +323,11 @@ void handle_client(int client_socket, SharedState& state) {
             char resp = '1';
             if (!send_all(&resp, 1)) break;
         }
+        else {
+            std::cerr << "[SERVER] Unknown cmd=" << (int)cmd << " — sending error response\n";
+            char resp = '0';
+            if (!send_all(&resp, 1)) break;
+        }
     }
 
     } catch (const std::exception& e) {


### PR DESCRIPTION
…c (closes #68)

Unknown command bytes previously fell through all branches without a response, causing the client to hang and the protocol stream to become permanently desynchronized. Now sends '0' error response and logs the invalid command.