### PR TITLE
fix: benchmark CI - use PR-based flow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,14 +33,16 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++
           cmake --build build --target CiBench -j$(nproc)
 
-      - name: Run benchmarks (push to main)
+      - name: Run benchmarks and create PR
         if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 benchmark/ci_bench.py commit
+          python3 benchmark/ci_bench.py prepare
           BRANCH="bench/report-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
+          git add benchmarks/data.json benchmarks/REPORT.md
+          git commit -m "bench: update performance report [$(git rev-parse --short HEAD)] [skip ci]"
           git push origin "$BRANCH"
           gh pr create --title "bench: update performance report" \
             --body "Auto-generated benchmark report update." \

--- a/benchmark/ci_bench.py
+++ b/benchmark/ci_bench.py
@@ -263,7 +263,7 @@ def git_commit(message):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: ci_bench.py [commit|pr]", file=sys.stderr)
+        print("Usage: ci_bench.py [commit|prepare|pr]", file=sys.stderr)
         sys.exit(1)
 
     mode = sys.argv[1]
@@ -274,7 +274,7 @@ def main():
     results = run_benchmark()
     print(f"Results: {json.dumps(results, indent=2)}", file=sys.stderr)
 
-    if mode == "commit":
+    if mode == "commit" or mode == "prepare":
         sha, msg = get_git_info()
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
@@ -294,7 +294,8 @@ def main():
         with open(REPORT_FILE, "w") as f:
             f.write(report)
 
-        git_commit(f"bench: update performance report [{sha}] [skip ci]")
+        if mode == "commit":
+            git_commit(f"bench: update performance report [{sha}] [skip ci]")
         print(f"\nReport updated. {len(history['results'])} entries in history.", file=sys.stderr)
 
     elif mode == "pr":


### PR DESCRIPTION
Fixes benchmark CI workflow. Previously, ci_bench.py committed directly to master, then the workflow redundantly created a branch + PR (which failed due to missing repo permission).\n\nNow: ci_bench.py prepare mode updates files without committing, then the workflow creates a branch, commits, pushes, and opens a PR.
