### PR TITLE
Pin FetchContent dependencies by hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,14 @@ find_package(Threads REQUIRED)
 FetchContent_Declare(
     spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG        v1.15.1
+    GIT_TAG        f355b3d58f7067eee1706ff3c801c2361011f3d5 # v1.15.1 -- pinned by commit hash, tags are mutable
 )
 FetchContent_MakeAvailable(spdlog)
 
 FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+    URL_HASH SHA256=1f357c27ca988c3f7c6b4bf68a9395005ac6761f034046e9dde0896e3aba00e4
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
Closes #98

## Problem

`spdlog` was fetched by git tag (`v1.15.1`) and `googletest` by a bare URL (`v1.14.0.zip`), with no integrity verification. Tags are mutable — they can be force-pushed to point at different content — and a plain URL download has no way to detect if the artifact changes. A compromised tag or compromised download would be silently fetched and built.

## Fix

- **spdlog**: `GIT_TAG` now pins the commit hash that `v1.15.1` currently resolves to (`f355b3d58f7067eee1706ff3c801c2361011f3d5`, verified via `git ls-remote`), with the tag name kept in a trailing comment for readability.
- **googletest**: added `URL_HASH SHA256=1f357c27ca988c3f7c6b4bf68a9395005ac6761f034046e9dde0896e3aba00e4` for the `v1.14.0.zip` archive, computed from the actual downloaded file (`shasum -a 256`).

## Testing

Ran `cmake -S . -B build` from a clean checkout: configuration completes successfully, both dependencies are fetched, and CMake verifies the googletest archive against the pinned SHA256 (a mismatch would fail the configure step). spdlog builds against the pinned commit, which is the same commit `v1.15.1` currently points to.