### PR TITLE
Pin numpy version range in Python SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: '3.9'
 
     - name: Install Python Dependencies
-      run: pip install numpy
+      run: pip install "numpy>=1.24,<2.0"
 
     # 3. Configure CMake
     - name: Configure CMake (Windows)

--- a/redbox-sdk/setup.py
+++ b/redbox-sdk/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/bibidhSubedi0/RedBoxDb",
     packages=find_packages(),       # Finds the 'redboxdb' folder automatically
     install_requires=[
-        "numpy",                    # Auto-installs numpy for the user
+        "numpy>=1.24,<2.0",         # Auto-installs numpy for the user
     ],
     include_package_data=True,
     package_data={


### PR DESCRIPTION
Closes #116

## Problem

`install_requires=["numpy"]` in `redbox-sdk/setup.py` had no version constraint, so a breaking numpy release could silently break the SDK for anyone installing it. CI installed numpy the same unconstrained way (`pip install numpy`).

## Fix

Pinned to `numpy>=1.24,<2.0` (the range suggested in the issue) in both:
- `redbox-sdk/setup.py`'s `install_requires`
- `.github/workflows/ci.yml`'s install step, so CI and the published package stay in sync

## Testing

Installed the SDK from a clean virtualenv (Python 3.11 — closer to CI's pinned `3.9` than this machine's default Python, which is too new for numpy 1.x wheels):

```
pip install -e redbox-sdk
```

Resolves `numpy==1.26.4` (within the pinned range) and `import redboxdb` succeeds.