### PR TITLE
Add coverage build type and lcov CI reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,57 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
+
+      - name: Configure CMake (Coverage build type)
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_CXX_COMPILER=g++
+
+      - name: Build
+        run: cmake --build build -j$(nproc) --target RedBoxDbTests
+
+      - name: Run C++ Unit Tests (GTest)
+        run: |
+          cd build/tests
+          ./RedBoxDbTests
+
+      - name: Capture coverage
+        run: |
+          lcov --directory build --capture --output-file coverage.info \
+            --ignore-errors mismatch,negative,gcov
+          # Drop third-party (FetchContent'd) sources, system headers, and
+          # the test files themselves -- we only want coverage of our own
+          # src/ and include/ code.
+          lcov --remove coverage.info \
+            '/usr/*' \
+            '*/build/_deps/*' \
+            '*/tests/*' \
+            '*/benchmark/*' \
+            --output-file coverage.filtered.info \
+            --ignore-errors unused
+          lcov --list coverage.filtered.info
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.filtered.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.filtered.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
 endif()
 
 include(cmake/StandardProjectSettings.cmake)
+include(cmake/Coverage.cmake)
 include(GNUInstallDirs)
 include(FetchContent)
 

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -1,0 +1,20 @@
+# Coverage.cmake
+#
+# Adds gcov/llvm-cov instrumentation when configured with
+# -DCMAKE_BUILD_TYPE=Coverage. No effect on any other build type.
+#
+# Usage:
+#   cmake -S . -B build -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_CXX_COMPILER=g++
+#   cmake --build build
+#   ctest --test-dir build
+#   lcov --directory build --capture --output-file coverage.info
+
+if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+    if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+        message(WARNING "Coverage build type requires GCC or Clang; got ${CMAKE_CXX_COMPILER_ID}. Coverage flags were not added.")
+    else()
+        message(STATUS "Coverage instrumentation enabled (--coverage)")
+        add_compile_options(-O0 -g --coverage)
+        add_link_options(--coverage)
+    endif()
+endif()


### PR DESCRIPTION
Closes #106

## Problem

No `gcov`/`lcov`/`llvm-cov` integration existed, so coverage of the server command handlers, HNSW graph code, and edge cases was unknown.

## Fix

- **`cmake/Coverage.cmake`**: a new `Coverage` build type (`-DCMAKE_BUILD_TYPE=Coverage`), matching the exact request in the issue. Adds `--coverage` (gcov instrumentation) on GCC/Clang; warns (without failing configure) on anything else. No effect on any other build type. Included from the top-level `CMakeLists.txt` next to the existing `StandardProjectSettings.cmake` include.
- **`.github/workflows/coverage.yml`**: a new CI job on `ubuntu-latest` (using `-DCMAKE_CXX_COMPILER=g++`, matching the toolchain `ci.yml` already targets) that:
  1. Configures with the `Coverage` build type
  2. Builds and runs `RedBoxDbTests`
  3. Captures coverage with `lcov`, then filters out third-party `FetchContent`'d sources, system headers, and the test/benchmark files themselves — so the report reflects `src/`/`include/` only
  4. Uploads the filtered report as a build artifact (so it's inspectable even without Codecov configured)
  5. Uploads to Codecov (`fail_ci_if_error: false`, so a missing `CODECOV_TOKEN` secret doesn't break CI)

## Testing

Verified locally on the CMake side:
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Coverage` configures cleanly, and `--coverage` is present in the generated `flags.make` for `RedBoxDbLib`, `RedBoxDbTests`, and the other real targets.
- A plain `-DCMAKE_BUILD_TYPE=Release` configure is unaffected by the new include (confirmed identical output aside from the build type itself).
- `actionlint` on the new workflow file surfaces no findings beyond the same class of cosmetic shellcheck warning (`SC2046`, unquoted `$(nproc)`) already present in this repo's own `benchmark.yml`.

**What I couldn't verify locally**: an actual instrumented build + `lcov` run end-to-end. This machine's C++ toolchain is missing standard library headers (even a bare `#include <atomic>` fails to compile) and has no GCC installed, only AppleClang — I can't reproduce the exact `ubuntu-latest` + `g++` environment this workflow targets. The CMake/flag changes are verified as above, but the actual build/test/lcov steps in `coverage.yml` haven't been run by me — please let CI confirm on this PR, and I'm happy to iterate if anything in the workflow needs adjusting once it runs for real.