### PR TITLE
feat: PostgreSQL metadata store + benchmark CI fix

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
           gh pr create --title "bench: update performance report" \
             --body "Auto-generated benchmark report update." \
             --base master --head "$BRANCH"
-          gh pr merge --auto --squash
+          gh pr merge --auto --squash || echo "Auto-merge not available (enable in repo settings)"
 
       - name: Run benchmarks and post comment (PR)
         if: github.event_name == 'pull_request'
@@ -56,6 +56,6 @@ jobs:
           echo "$COMMENT" > /tmp/bench_comment.md
           gh pr comment ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --body-file /tmp/bench_comment.md
+            --body-file /tmp/bench_comment.md || echo "Could not post comment (fork PR or permission issue)"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,27 +13,7 @@ jobs:
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_DB: redbox_test
-          POSTGRES_USER: redbox
-          POSTGRES_PASSWORD: test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     env:
-      REDBOX_PG_HOST: localhost
-      REDBOX_PG_PORT: "5432"
-      REDBOX_PG_DBNAME: redbox_test
-      REDBOX_PG_USER: redbox
-      REDBOX_PG_PASSWORD: test
       REDBOX_DATA_DIR: /tmp/redbox_data
 
     steps:
@@ -49,10 +29,34 @@ jobs:
     - name: Install Python Dependencies
       run: pip install "numpy>=1.24,<2.0"
 
-    # 3. Install PostgreSQL dev libraries (Linux)
-    - name: Install libpq-dev (Linux)
+    # 3. Start PostgreSQL (Linux only)
+    - name: Start PostgreSQL (Linux)
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libpq-dev postgresql-client
+      run: |
+        sudo apt-get update && sudo apt-get install -y libpq-dev postgresql
+        sudo systemctl start postgresql
+        sudo -u postgres psql -c "CREATE USER redbox WITH PASSWORD 'test';"
+        sudo -u postgres psql -c "CREATE DATABASE redbox_test OWNER redbox;"
+      env:
+        PGHOST: /var/run/postgresql
+
+    - name: Set PG env vars (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        echo "REDBOX_PG_HOST=localhost" >> $GITHUB_ENV
+        echo "REDBOX_PG_PORT=5432" >> $GITHUB_ENV
+        echo "REDBOX_PG_DBNAME=redbox_test" >> $GITHUB_ENV
+        echo "REDBOX_PG_USER=redbox" >> $GITHUB_ENV
+        echo "REDBOX_PG_PASSWORD=test" >> $GITHUB_ENV
+
+    - name: Set PG env vars (Windows - skip)
+      if: runner.os == 'Windows'
+      run: |
+        echo "REDBOX_PG_HOST=" >> $env:GITHUB_ENV
+        echo "REDBOX_PG_PORT=" >> $env:GITHUB_ENV
+        echo "REDBOX_PG_DBNAME=" >> $env:GITHUB_ENV
+        echo "REDBOX_PG_USER=" >> $env:GITHUB_ENV
+        echo "REDBOX_PG_PASSWORD=" >> $env:GITHUB_ENV
 
     # 4. Configure CMake
     - name: Configure CMake (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
 
     env:
       REDBOX_DATA_DIR: /tmp/redbox_data
-
     steps:
     # 1. Checkout Code
     - uses: actions/checkout@v4
@@ -57,6 +56,7 @@ jobs:
         echo "REDBOX_PG_DBNAME=" >> $env:GITHUB_ENV
         echo "REDBOX_PG_USER=" >> $env:GITHUB_ENV
         echo "REDBOX_PG_PASSWORD=" >> $env:GITHUB_ENV
+        echo "REDBOX_DATA_DIR=C:\temp\redbox_data" >> $env:GITHUB_ENV
 
     # 4. Configure CMake
     - name: Configure CMake (Windows)
@@ -72,8 +72,14 @@ jobs:
       run: cmake --build build
 
     # 6. Create data directory
-    - name: Create data directory
+    - name: Create data directory (Linux)
+      if: runner.os == 'Linux'
       run: mkdir -p /tmp/redbox_data
+
+    - name: Create data directory (Windows)
+      if: runner.os == 'Windows'
+      run: mkdir -force C:\temp\redbox_data
+      shell: powershell
 
     # 7. Run C++ Unit Tests (GTest)
     - name: Run C++ Unit Tests (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     # 4. Configure CMake
     - name: Configure CMake (Windows)
       if: runner.os == 'Windows'
-      run: cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++
+      run: cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -DREDBOX_ENABLE_PG=OFF
 
     - name: Configure CMake (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,29 @@ jobs:
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: redbox_test
+          POSTGRES_USER: redbox
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      REDBOX_PG_HOST: localhost
+      REDBOX_PG_PORT: "5432"
+      REDBOX_PG_DBNAME: redbox_test
+      REDBOX_PG_USER: redbox
+      REDBOX_PG_PASSWORD: test
+      REDBOX_DATA_DIR: /tmp/redbox_data
+
     steps:
     # 1. Checkout Code
     - uses: actions/checkout@v4
@@ -26,7 +49,12 @@ jobs:
     - name: Install Python Dependencies
       run: pip install "numpy>=1.24,<2.0"
 
-    # 3. Configure CMake
+    # 3. Install PostgreSQL dev libraries (Linux)
+    - name: Install libpq-dev (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y libpq-dev postgresql-client
+
+    # 4. Configure CMake
     - name: Configure CMake (Windows)
       if: runner.os == 'Windows'
       run: cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++
@@ -35,11 +63,15 @@ jobs:
       if: runner.os == 'Linux'
       run: cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++
 
-    # 4. Build the Server & Tests
+    # 5. Build the Server & Tests
     - name: Build Project
       run: cmake --build build
 
-    # 5. Run C++ Unit Tests (GTest)
+    # 6. Create data directory
+    - name: Create data directory
+      run: mkdir -p /tmp/redbox_data
+
+    # 7. Run C++ Unit Tests (GTest)
     - name: Run C++ Unit Tests (Windows)
       if: runner.os == 'Windows'
       run: |
@@ -52,7 +84,7 @@ jobs:
         cd build/tests
         ./RedBoxDbTests
 
-    # 6. Run Python Integration Tests
+    # 8. Run Python Integration Tests
     - name: Run System Verification (Windows)
       if: runner.os == 'Windows'
       shell: powershell

--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,6 @@ venv/
 *.db
 *.del
 build_mingw.vscode/
+
+build-profile/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,17 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+find_package(PostgreSQL REQUIRED)
+
+FetchContent_Declare(
+    libpqxx
+    GIT_REPOSITORY https://github.com/jtv/libpqxx.git
+    GIT_TAG        8.0.2
+)
+set(PQXX_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(PQXX_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(libpqxx)
+
 add_subdirectory(src)
 add_subdirectory(tests)
 add_subdirectory(benchmark)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,16 +32,28 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-find_package(PostgreSQL REQUIRED)
+option(REDBOX_ENABLE_PG "Enable PostgreSQL metadata store" ON)
 
-FetchContent_Declare(
-    libpqxx
-    GIT_REPOSITORY https://github.com/jtv/libpqxx.git
-    GIT_TAG        8.0.2
-)
-set(PQXX_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(PQXX_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(libpqxx)
+if(REDBOX_ENABLE_PG)
+    find_package(PostgreSQL)
+    if(PostgreSQL_FOUND)
+        FetchContent_Declare(
+            libpqxx
+            GIT_REPOSITORY https://github.com/jtv/libpqxx.git
+            GIT_TAG        8.0.2
+        )
+        set(PQXX_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+        set(PQXX_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(libpqxx)
+        add_compile_definitions(REDBOX_PG_ENABLED)
+        message(STATUS "PostgreSQL support: ENABLED")
+    else()
+        set(REDBOX_ENABLE_PG OFF)
+        message(STATUS "PostgreSQL not found: metadata store DISABLED")
+    endif()
+else()
+    message(STATUS "PostgreSQL support: DISABLED (REDBOX_ENABLE_PG=OFF)")
+endif()
 
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/include/redboxdb/engine.hpp
+++ b/include/redboxdb/engine.hpp
@@ -74,6 +74,12 @@ namespace CoreEngine {
         void     set_hnsw_ef_search(uint16_t ef);
         void     warm_pages();
 
+        uint64_t get_count() const { return _manager->get_count(); }
+        uint64_t get_next_id() const { return _manager->get_header()->next_id; }
+        void     set_next_id(uint64_t id) { _manager->get_header()->next_id = id; }
+        void     set_vector_count(uint64_t c) { _manager->get_header()->vector_count = c; }
+        CoreEngine::SpecificMetadata* get_header() { return _manager->get_header(); }
+
         // Tombstone helpers
         void load_tombstones();
         void append_tombstone(uint64_t id);

--- a/include/redboxdb/metadata_store.hpp
+++ b/include/redboxdb/metadata_store.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <cstdint>
+#include <mutex>
+#include <redboxdb/SpecificMetadata.hpp>
+
+namespace Metadata {
+
+struct DbInfo {
+    std::string name;
+    uint32_t    dimensions;
+    CoreEngine::IndexType index_type;
+    uint64_t    capacity;
+    uint64_t    vector_count;
+    uint64_t    next_id;
+};
+
+class Store {
+public:
+    Store(const std::string& conninfo, int pool_size = 4);
+    ~Store();
+
+    Store(const Store&) = delete;
+    Store& operator=(const Store&) = delete;
+
+    void run_migrations(const std::string& schema_path);
+    void seed_from_files(const std::string& data_dir);
+
+    void create_database(const std::string& name, uint32_t dim,
+                         CoreEngine::IndexType type, uint64_t capacity,
+                         const CoreEngine::SpecificMetadata& params);
+    void load_database(const std::string& name, CoreEngine::SpecificMetadata& out);
+    void update_counts(const std::string& name, uint64_t vector_count, uint64_t next_id);
+    void update_hnsw_state(const std::string& name, uint32_t entry_point, uint32_t graph_version);
+    void drop_database(const std::string& name);
+    void list_databases(std::vector<DbInfo>& out);
+
+    void log_operation(const std::string& db_name, const std::string& op, uint64_t vec_id = 0);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}

--- a/redbox-sdk/redboxdb/client.py
+++ b/redbox-sdk/redboxdb/client.py
@@ -199,6 +199,70 @@ class RedBoxClient:
         resp = self.sock.recv(1)
         return resp == b'1'
 
+    def list_databases(self) -> List[dict]:
+        """
+        List all databases in the metadata store.
+        Protocol: [CMD=12] [0]
+        Returns: List of dicts with name, dimensions, index_type, vector_count.
+        """
+        header = struct.pack('<BI', 12, 0)
+        self.sock.sendall(header)
+
+        count_bytes = self._recv_exact(4)
+        count = struct.unpack('<I', count_bytes)[0]
+
+        dbs = []
+        for _ in range(count):
+            name_len = struct.unpack('B', self._recv_exact(1))[0]
+            name = self._recv_exact(name_len).decode('utf-8')
+            dim = struct.unpack('<I', self._recv_exact(4))[0]
+            idx_type = struct.unpack('B', self._recv_exact(1))[0]
+            vec_count = struct.unpack('<Q', self._recv_exact(8))[0]
+            dbs.append({
+                'name': name,
+                'dimensions': dim,
+                'index_type': 'HNSW' if idx_type == 1 else 'IVF',
+                'vector_count': vec_count,
+            })
+        return dbs
+
+    def database_info(self) -> dict:
+        """
+        Get metadata for the active database.
+        Protocol: [CMD=13] [0]
+        Returns: dict with vector_count, capacity, next_id, index_type, dimensions.
+        """
+        header = struct.pack('<BI', 13, 0)
+        self.sock.sendall(header)
+
+        ok = self._recv_exact(1)
+        if ok != b'\x01':
+            raise RuntimeError("database_info failed: no active database")
+
+        vc = struct.unpack('<Q', self._recv_exact(8))[0]
+        cap = struct.unpack('<Q', self._recv_exact(8))[0]
+        nid = struct.unpack('<Q', self._recv_exact(8))[0]
+        idx_type = struct.unpack('B', self._recv_exact(1))[0]
+        dim = struct.unpack('<I', self._recv_exact(4))[0]
+
+        return {
+            'vector_count': vc,
+            'capacity': cap,
+            'next_id': nid,
+            'index_type': 'HNSW' if idx_type == 1 else 'IVF',
+            'dimensions': dim,
+        }
+
+    def _recv_exact(self, n: int) -> bytes:
+        """Receive exactly n bytes from the socket."""
+        buf = b''
+        while len(buf) < n:
+            chunk = self.sock.recv(n - len(buf))
+            if not chunk:
+                raise ConnectionError("Connection closed while reading response.")
+            buf += chunk
+        return buf
+
     def close(self):
         """Cleanly close the connection."""
         if self.sock:

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,46 @@
+-- RedBoxDb PostgreSQL Metadata Schema
+-- Run once on first startup to create tables.
+
+DO $$ BEGIN
+    CREATE TYPE index_type AS ENUM ('IVF', 'HNSW');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS databases (
+    id                    SERIAL PRIMARY KEY,
+    name                  VARCHAR(64) UNIQUE NOT NULL,
+    dimensions            INTEGER NOT NULL,
+    index_type            index_type NOT NULL DEFAULT 'IVF',
+    capacity              BIGINT NOT NULL,
+    vector_count          BIGINT NOT NULL DEFAULT 0,
+    next_id               BIGINT NOT NULL DEFAULT 1,
+    hnsw_m                SMALLINT,
+    hnsw_ef_construction  SMALLINT,
+    hnsw_ef_search        SMALLINT,
+    hnsw_max_level        SMALLINT,
+    hnsw_entry_point      INTEGER DEFAULT 0,
+    hnsw_graph_version    INTEGER DEFAULT 0,
+    ivf_num_clusters      SMALLINT,
+    ivf_num_probes        SMALLINT,
+    ivf_initialized       BOOLEAN DEFAULT FALSE,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id          BIGSERIAL PRIMARY KEY,
+    db_name     VARCHAR(64) REFERENCES databases(name) ON DELETE CASCADE,
+    operation   VARCHAR(16) NOT NULL,
+    vector_id   BIGINT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_db_time ON audit_log(db_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_time ON audit_log(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS server_config (
+    key         VARCHAR(64) PRIMARY KEY,
+    value       TEXT NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,15 +6,22 @@ add_library(RedBoxDbLib)
 target_sources(RedBoxDbLib
     PRIVATE
         engine.cpp
-        metadata_store.cpp
  )
+
+if(REDBOX_ENABLE_PG)
+    target_sources(RedBoxDbLib PRIVATE metadata_store.cpp)
+endif()
 
 target_include_directories(RedBoxDbLib
     PUBLIC
         ${PROJECT_SOURCE_DIR}/include
 )
 
-target_link_libraries(RedBoxDbLib PRIVATE spdlog::spdlog Threads::Threads pqxx PostgreSQL::PostgreSQL)
+target_link_libraries(RedBoxDbLib PRIVATE spdlog::spdlog Threads::Threads)
+
+if(REDBOX_ENABLE_PG)
+    target_link_libraries(RedBoxDbLib PRIVATE pqxx PostgreSQL::PostgreSQL)
+endif()
 
 include(CheckCXXCompilerFlag)
 
@@ -63,6 +70,10 @@ target_link_libraries(RedBoxServer
         spdlog::spdlog
         Threads::Threads
 )
+
+if(REDBOX_ENABLE_PG)
+    target_link_libraries(RedBoxServer PRIVATE pqxx PostgreSQL::PostgreSQL)
+endif()
 
 # Only link Winsock on Windows
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(RedBoxDbLib)
 target_sources(RedBoxDbLib
     PRIVATE
         engine.cpp
+        metadata_store.cpp
  )
 
 target_include_directories(RedBoxDbLib
@@ -13,7 +14,7 @@ target_include_directories(RedBoxDbLib
         ${PROJECT_SOURCE_DIR}/include
 )
 
-target_link_libraries(RedBoxDbLib PRIVATE spdlog::spdlog Threads::Threads)
+target_link_libraries(RedBoxDbLib PRIVATE spdlog::spdlog Threads::Threads pqxx PostgreSQL::PostgreSQL)
 
 include(CheckCXXCompilerFlag)
 

--- a/src/metadata_store.cpp
+++ b/src/metadata_store.cpp
@@ -1,0 +1,270 @@
+#include "redboxdb/metadata_store.hpp"
+#include <pqxx/pqxx>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <filesystem>
+#include <cstring>
+#include <unordered_set>
+
+#include <redboxdb/SpecificMetadata.hpp>
+
+#ifndef _WIN32
+    #include <sys/mman.h>
+    #include <sys/stat.h>
+    #include <fcntl.h>
+    #include <unistd.h>
+#else
+    #include <windows.h>
+    #include <fcntl.h>
+    #include <io.h>
+#endif
+
+namespace Metadata {
+
+struct Store::Impl {
+    std::unique_ptr<pqxx::connection> conn;
+    std::mutex mtx;
+
+    explicit Impl(const std::string& conninfo)
+        : conn(std::make_unique<pqxx::connection>(conninfo))
+    {}
+};
+
+Store::Store(const std::string& conninfo, int /*pool_size*/)
+    : impl_(std::make_unique<Impl>(conninfo))
+{
+    std::cout << "[METADATA] Connected to PostgreSQL\n";
+}
+
+Store::~Store() = default;
+
+void Store::run_migrations(const std::string& schema_path) {
+    std::ifstream file(schema_path);
+    if (!file.is_open()) {
+        throw std::runtime_error("Cannot open schema file: " + schema_path);
+    }
+    std::stringstream ss;
+    ss << file.rdbuf();
+    std::string sql = ss.str();
+
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    pqxx::work tx(*impl_->conn);
+    tx.exec(sql);
+    tx.commit();
+    std::cout << "[METADATA] Schema migrations applied from " << schema_path << "\n";
+}
+
+void Store::create_database(const std::string& name, uint32_t dim,
+                            CoreEngine::IndexType type, uint64_t capacity,
+                            const CoreEngine::SpecificMetadata& params) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    pqxx::work tx(*impl_->conn);
+
+    std::string type_str = (type == CoreEngine::IndexType::HNSW) ? "HNSW" : "IVF";
+
+    tx.exec(
+        "INSERT INTO databases (name, dimensions, index_type, capacity, vector_count, next_id, "
+        "hnsw_m, hnsw_ef_construction, hnsw_ef_search, hnsw_max_level, hnsw_entry_point, "
+        "hnsw_graph_version, ivf_num_clusters, ivf_num_probes, ivf_initialized) "
+        "VALUES ($1, $2, $3::index_type, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+        pqxx::params{name, (int)dim, type_str, (long)capacity,
+                     (long)params.vector_count, (long)params.next_id,
+                     (int)params.hnsw_M, (int)params.hnsw_ef_construction,
+                     (int)params.hnsw_ef_search, (int)params.hnsw_max_level,
+                     (int)params.hnsw_entry_point, (int)params.hnsw_graph_version,
+                     (int)params.num_clusters, (int)params.num_probes,
+                     params.is_initialized != 0}
+    );
+    tx.commit();
+    std::cout << "[METADATA] Created database: " << name << " (" << type_str << ", dim=" << dim << ")\n";
+}
+
+void Store::load_database(const std::string& name, CoreEngine::SpecificMetadata& out) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    pqxx::read_transaction tx(*impl_->conn);
+
+    auto result = tx.exec(
+        "SELECT dimensions, index_type, capacity, vector_count, next_id, "
+        "hnsw_m, hnsw_ef_construction, hnsw_ef_search, hnsw_max_level, "
+        "hnsw_entry_point, hnsw_graph_version, "
+        "ivf_num_clusters, ivf_num_probes, ivf_initialized "
+        "FROM databases WHERE name = $1",
+        pqxx::params{name}
+    );
+
+    if (result.empty()) {
+        throw std::runtime_error("Database not found in metadata: " + name);
+    }
+
+    auto row = result[0];
+    memset(&out, 0, sizeof(out));
+
+    out.dimensions     = row["dimensions"].as<uint64_t>();
+    out.vector_count   = row["vector_count"].as<uint64_t>();
+    out.max_capacity   = row["capacity"].as<uint64_t>();
+    out.next_id        = row["next_id"].as<uint64_t>();
+    out.data_type_size = 4;
+
+    std::string idx = row["index_type"].as<std::string>();
+    out.index_type = (idx == "HNSW") ? static_cast<uint8_t>(CoreEngine::IndexType::HNSW)
+                                     : static_cast<uint8_t>(CoreEngine::IndexType::IVF);
+
+    if (out.index_type == static_cast<uint8_t>(CoreEngine::IndexType::HNSW)) {
+        out.hnsw_M               = row["hnsw_m"].as<int>();
+        out.hnsw_ef_construction  = row["hnsw_ef_construction"].as<int>();
+        out.hnsw_ef_search        = row["hnsw_ef_search"].as<int>();
+        out.hnsw_max_level        = row["hnsw_max_level"].as<int>();
+        out.hnsw_entry_point      = row["hnsw_entry_point"].as<uint32_t>();
+        out.hnsw_graph_version    = row["hnsw_graph_version"].as<uint32_t>();
+    } else {
+        out.num_clusters  = row["ivf_num_clusters"].as<int>();
+        out.num_probes    = row["ivf_num_probes"].as<int>();
+        out.is_initialized = row["ivf_initialized"].as<bool>() ? 1 : 0;
+    }
+
+    out.version = CoreEngine::SpecificMetadata::CURRENT_VERSION;
+}
+
+void Store::update_counts(const std::string& name, uint64_t vector_count, uint64_t next_id) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    pqxx::work tx(*impl_->conn);
+    tx.exec(
+        "UPDATE databases SET vector_count = $1, next_id = $2, updated_at = NOW() WHERE name = $3",
+        pqxx::params{(long)vector_count, (long)next_id, name}
+    );
+    tx.commit();
+}
+
+void Store::update_hnsw_state(const std::string& name, uint32_t entry_point, uint32_t graph_version) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    pqxx::work tx(*impl_->conn);
+    tx.exec(
+        "UPDATE databases SET hnsw_entry_point = $1, hnsw_graph_version = $2, updated_at = NOW() WHERE name = $3",
+        pqxx::params{(int)entry_point, (int)graph_version, name}
+    );
+    tx.commit();
+}
+
+void Store::drop_database(const std::string& name) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    pqxx::work tx(*impl_->conn);
+    tx.exec("DELETE FROM databases WHERE name = $1", pqxx::params{name});
+    tx.commit();
+    std::cout << "[METADATA] Dropped database: " << name << "\n";
+}
+
+void Store::list_databases(std::vector<DbInfo>& out) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    pqxx::read_transaction tx(*impl_->conn);
+
+    auto result = tx.exec(
+        "SELECT name, dimensions, index_type, capacity, vector_count, next_id FROM databases ORDER BY name"
+    );
+
+    out.clear();
+    out.reserve(result.size());
+    for (auto row : result) {
+        DbInfo info;
+        info.name         = row["name"].as<std::string>();
+        info.dimensions   = row["dimensions"].as<uint32_t>();
+        info.capacity     = row["capacity"].as<uint64_t>();
+        info.vector_count = row["vector_count"].as<uint64_t>();
+        info.next_id      = row["next_id"].as<uint64_t>();
+
+        std::string idx = row["index_type"].as<std::string>();
+        info.index_type  = (idx == "HNSW") ? CoreEngine::IndexType::HNSW
+                                           : CoreEngine::IndexType::IVF;
+        out.push_back(std::move(info));
+    }
+}
+
+void Store::log_operation(const std::string& db_name, const std::string& op, uint64_t vec_id) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    try {
+        pqxx::work tx(*impl_->conn);
+        tx.exec(
+            "INSERT INTO audit_log (db_name, operation, vector_id) VALUES ($1, $2, $3)",
+            pqxx::params{db_name, op, (long)vec_id}
+        );
+        tx.commit();
+    } catch (const std::exception& e) {
+        std::cerr << "[METADATA] Audit log error: " << e.what() << "\n";
+    }
+}
+
+void Store::seed_from_files(const std::string& data_dir) {
+    namespace fs = std::filesystem;
+
+    if (!fs::exists(data_dir)) {
+        std::cout << "[METADATA] Data directory not found, skipping seed: " << data_dir << "\n";
+        return;
+    }
+
+    std::unordered_set<std::string> known;
+    {
+        std::lock_guard<std::mutex> lock(impl_->mtx);
+        pqxx::read_transaction tx(*impl_->conn);
+        auto existing = tx.exec("SELECT name FROM databases");
+        for (auto row : existing) {
+            known.insert(row["name"].as<std::string>());
+        }
+    }
+
+    for (auto& entry : fs::directory_iterator(data_dir)) {
+        if (!entry.is_regular_file()) continue;
+        std::string path = entry.path().string();
+        std::string ext = entry.path().extension().string();
+        if (ext != ".db") continue;
+
+        std::string db_name = entry.path().stem().string();
+        if (known.count(db_name)) continue;
+
+        int fd = open(path.c_str(), O_RDONLY);
+        if (fd < 0) continue;
+
+        struct stat st;
+        if (fstat(fd, &st) < 0 || st.st_size < 128) {
+            close(fd);
+            continue;
+        }
+
+        void* map = mmap(nullptr, 128, PROT_READ, MAP_PRIVATE, fd, 0);
+        if (map == MAP_FAILED) {
+            close(fd);
+            continue;
+        }
+
+        CoreEngine::SpecificMetadata header;
+        memcpy(&header, map, sizeof(header));
+        munmap(map, 128);
+        close(fd);
+
+        std::cout << "[METADATA] Seeding from file: " << db_name
+                  << " (dim=" << header.dimensions
+                  << " count=" << header.vector_count
+                  << " type=" << (header.index_type == 1 ? "HNSW" : "IVF") << ")\n";
+
+        std::lock_guard<std::mutex> lock(impl_->mtx);
+        pqxx::work tx(*impl_->conn);
+        tx.exec(
+            "INSERT INTO databases (name, dimensions, index_type, capacity, vector_count, next_id, "
+            "hnsw_m, hnsw_ef_construction, hnsw_ef_search, hnsw_max_level, hnsw_entry_point, "
+            "hnsw_graph_version, ivf_num_clusters, ivf_num_probes, ivf_initialized) "
+            "VALUES ($1, $2, $3::index_type, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) "
+            "ON CONFLICT (name) DO NOTHING",
+            pqxx::params{db_name, (int)header.dimensions,
+                         (header.index_type == 1) ? "HNSW" : "IVF",
+                         (long)header.max_capacity, (long)header.vector_count, (long)header.next_id,
+                         (int)header.hnsw_M, (int)header.hnsw_ef_construction,
+                         (int)header.hnsw_ef_search, (int)header.hnsw_max_level,
+                         (int)header.hnsw_entry_point, (int)header.hnsw_graph_version,
+                         (int)header.num_clusters, (int)header.num_probes,
+                         header.is_initialized != 0}
+        );
+        tx.commit();
+        std::cout << "[METADATA] Seeded: " << db_name << "\n";
+    }
+}
+
+}

--- a/src/metadata_store.cpp
+++ b/src/metadata_store.cpp
@@ -9,17 +9,6 @@
 
 #include <redboxdb/SpecificMetadata.hpp>
 
-#ifndef _WIN32
-    #include <sys/mman.h>
-    #include <sys/stat.h>
-    #include <fcntl.h>
-    #include <unistd.h>
-#else
-    #include <windows.h>
-    #include <fcntl.h>
-    #include <io.h>
-#endif
-
 namespace Metadata {
 
 struct Store::Impl {
@@ -220,25 +209,12 @@ void Store::seed_from_files(const std::string& data_dir) {
         std::string db_name = entry.path().stem().string();
         if (known.count(db_name)) continue;
 
-        int fd = open(path.c_str(), O_RDONLY);
-        if (fd < 0) continue;
+        std::ifstream ifs(path, std::ios::binary);
+        if (!ifs) continue;
 
-        struct stat st;
-        if (fstat(fd, &st) < 0 || st.st_size < 128) {
-            close(fd);
-            continue;
-        }
-
-        void* map = mmap(nullptr, 128, PROT_READ, MAP_PRIVATE, fd, 0);
-        if (map == MAP_FAILED) {
-            close(fd);
-            continue;
-        }
-
-        CoreEngine::SpecificMetadata header;
-        memcpy(&header, map, sizeof(header));
-        munmap(map, 128);
-        close(fd);
+        CoreEngine::SpecificMetadata header{};
+        ifs.read(reinterpret_cast<char*>(&header), sizeof(header));
+        if (ifs.gcount() < static_cast<std::streamsize>(sizeof(header))) continue;
 
         std::cout << "[METADATA] Seeding from file: " << db_name
                   << " (dim=" << header.dimensions

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -16,7 +16,11 @@
 #include <thread>
 #include <mutex>
 #include "redboxdb/engine.hpp"
+#ifdef REDBOX_PG_ENABLED
 #include "redboxdb/metadata_store.hpp"
+#else
+namespace Metadata { class Store; struct DbInfo {}; }
+#endif
 #include <filesystem>
 #include <cstring>
 #include <cctype>
@@ -165,11 +169,13 @@ void handle_client(int client_socket, SharedState& state) {
                         filename, requested_dim, (int)requested_capacity);
                     state.db_mutexes[db_name] = std::make_unique<std::mutex>();
 
+#ifdef REDBOX_PG_ENABLED
                     if (state.meta) {
                         state.meta->create_database(db_name, requested_dim,
                             CoreEngine::IndexType::IVF, requested_capacity,
                             *state.catalog[db_name]->get_header());
                     }
+#endif
                 }
 
                 active_db = state.catalog[db_name].get();
@@ -225,11 +231,13 @@ void handle_client(int client_socket, SharedState& state) {
                         hnsw_M, hnsw_ef_construction);
                     state.db_mutexes[db_name] = std::make_unique<std::mutex>();
 
+#ifdef REDBOX_PG_ENABLED
                     if (state.meta) {
                         state.meta->create_database(db_name, requested_dim,
                             CoreEngine::IndexType::HNSW, requested_capacity,
                             *state.catalog[db_name]->get_header());
                     }
+#endif
                 }
                 active_db = state.catalog[db_name].get();
                 active_mtx = state.db_mutexes[db_name].get();
@@ -249,10 +257,12 @@ void handle_client(int client_socket, SharedState& state) {
             std::vector<float> vec(current_dim);
             if (!recv_all((char*)vec.data(), vec_byte_size)) break;
             { std::lock_guard<std::mutex> lk(*active_mtx); active_db->insert(meta_data, vec); }
+#ifdef REDBOX_PG_ENABLED
             if (state.meta) {
                 state.meta->update_counts(active_db_name, active_db->get_count(), active_db->get_next_id());
                 state.meta->log_operation(active_db_name, "INSERT", meta_data);
             }
+#endif
             if (!send_all("1", 1)) break;
         }
         else if (cmd == CMD_SEARCH) {
@@ -260,18 +270,22 @@ void handle_client(int client_socket, SharedState& state) {
             if (!recv_all((char*)query.data(), vec_byte_size)) break;
             int result_id;
             { std::lock_guard<std::mutex> lk(*active_mtx); result_id = active_db->search(query); }
+#ifdef REDBOX_PG_ENABLED
             if (state.meta) {
                 state.meta->log_operation(active_db_name, "SEARCH", 0);
             }
+#endif
             if (!send_all((char*)&result_id, 4)) break;
         }
         else if (cmd == CMD_DELETE) {
             bool success;
             { std::lock_guard<std::mutex> lk(*active_mtx); success = active_db->remove(meta_data); }
+#ifdef REDBOX_PG_ENABLED
             if (success && state.meta) {
                 state.meta->update_counts(active_db_name, active_db->get_count(), active_db->get_next_id());
                 state.meta->log_operation(active_db_name, "DELETE", meta_data);
             }
+#endif
             char resp = success ? '1' : '0';
             if (!send_all(&resp, 1)) break;
         }
@@ -280,9 +294,11 @@ void handle_client(int client_socket, SharedState& state) {
             if (!recv_all((char*)vec.data(), vec_byte_size)) break;
             bool success;
             { std::lock_guard<std::mutex> lk(*active_mtx); success = active_db->update(meta_data, vec); }
+#ifdef REDBOX_PG_ENABLED
             if (success && state.meta) {
                 state.meta->log_operation(active_db_name, "UPDATE", meta_data);
             }
+#endif
             char resp = success ? '1' : '0';
             if (!send_all(&resp, 1)) break;
         }
@@ -291,10 +307,12 @@ void handle_client(int client_socket, SharedState& state) {
             if (!recv_all((char*)vec.data(), vec_byte_size)) break;
             uint64_t assigned_id;
             { std::lock_guard<std::mutex> lk(*active_mtx); assigned_id = active_db->insert_auto(vec); }
+#ifdef REDBOX_PG_ENABLED
             if (state.meta) {
                 state.meta->update_counts(active_db_name, active_db->get_count(), active_db->get_next_id());
                 state.meta->log_operation(active_db_name, "INSERT_AUTO", assigned_id);
             }
+#endif
             if (!send_all((char*)&assigned_id, sizeof(assigned_id))) break;
         }
         else if (cmd == CMD_SEARCH_N) {
@@ -328,9 +346,11 @@ void handle_client(int client_socket, SharedState& state) {
                     }
                 }
                 if (!db_to_drop.empty()) {
+#ifdef REDBOX_PG_ENABLED
                     if (state.meta) {
                         state.meta->drop_database(db_to_drop);
                     }
+#endif
                     state.catalog.erase(db_to_drop);
                     state.db_mutexes.erase(db_to_drop);
                     std::filesystem::remove(db_to_drop + ".db");
@@ -364,6 +384,7 @@ void handle_client(int client_socket, SharedState& state) {
             if (!send_all(&resp, 1)) break;
         }
         else if (cmd == CMD_LIST_DBS) {
+#ifdef REDBOX_PG_ENABLED
             if (!state.meta) {
                 uint32_t count = 0;
                 if (!send_all((char*)&count, sizeof(count))) break;
@@ -382,9 +403,17 @@ void handle_client(int client_socket, SharedState& state) {
                     if (!send_all((char*)&db.vector_count, sizeof(db.vector_count))) break;
                 }
             }
+#else
+            uint32_t count = 0;
+            if (!send_all((char*)&count, sizeof(count))) break;
+#endif
             continue;
         }
         else if (cmd == CMD_DB_INFO) {
+#ifndef REDBOX_PG_ENABLED
+            char zero = 0;
+            if (!send_all(&zero, 1)) break;
+#else
             if (!active_db || !state.meta) {
                 char zero = 0;
                 if (!send_all(&zero, 1)) break;
@@ -402,6 +431,7 @@ void handle_client(int client_socket, SharedState& state) {
                 if (!send_all((char*)&idx, 1)) break;
                 if (!send_all((char*)&dim, sizeof(dim))) break;
             }
+#endif
             continue;
         }
         else {
@@ -436,6 +466,7 @@ int main() {
     SharedState state;
 
     // --- PostgreSQL metadata store (optional) ---
+#ifdef REDBOX_PG_ENABLED
     const char* pg_host     = std::getenv("REDBOX_PG_HOST");
     const char* pg_port     = std::getenv("REDBOX_PG_PORT");
     const char* pg_dbname   = std::getenv("REDBOX_PG_DBNAME");
@@ -484,6 +515,9 @@ int main() {
     } else {
         std::cout << "[SERVER] REDBOX_PG_HOST not set. Running without metadata persistence.\n";
     }
+#else
+    std::cout << "[SERVER] PostgreSQL support not compiled in. Running without metadata persistence.\n";
+#endif
 
 #ifdef _WIN32
     SOCKET server_socket = socket(AF_INET, SOCK_STREAM, 0);
@@ -532,7 +566,9 @@ int main() {
     }
 
     closesocket(server_socket);
+#ifdef REDBOX_PG_ENABLED
     delete state.meta;
+#endif
 #ifdef _WIN32
     WSACleanup();
 #endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -16,9 +16,11 @@
 #include <thread>
 #include <mutex>
 #include "redboxdb/engine.hpp"
+#include "redboxdb/metadata_store.hpp"
 #include <filesystem>
 #include <cstring>
 #include <cctype>
+#include <cstdlib>
 
 #ifdef _WIN32
     #include <winsock2.h>
@@ -52,6 +54,8 @@ const uint8_t CMD_DROP_DB  = 8;
 const uint8_t CMD_SET_PROBES = 9;
 const uint8_t CMD_CREATE_HNSW_DB = 10;
 const uint8_t CMD_SET_HNSW_EF = 11;
+const uint8_t CMD_LIST_DBS = 12;
+const uint8_t CMD_DB_INFO = 13;
 
 constexpr size_t MAX_DB_NAME_LEN = 64;
 inline bool is_valid_db_name(const std::string& name) {
@@ -69,7 +73,8 @@ using MutexMap = std::unordered_map<std::string, std::unique_ptr<std::mutex>>;
 struct SharedState {
     DbCatalog  catalog;
     MutexMap   db_mutexes;
-    std::mutex catalog_mutex; // guards catalog + db_mutexes maps themselves
+    std::mutex catalog_mutex;
+    Metadata::Store* meta = nullptr;
 };
 
 // -----------------------------------------------------------------------
@@ -86,6 +91,7 @@ void handle_client(int client_socket, SharedState& state) {
 
     CoreEngine::RedBoxVector* active_db = nullptr;
     std::mutex* active_mtx = nullptr;
+    std::string active_db_name;
 
     char header_buffer[5];
 
@@ -158,10 +164,17 @@ void handle_client(int client_socket, SharedState& state) {
                     state.catalog[db_name] = std::make_unique<CoreEngine::RedBoxVector>(
                         filename, requested_dim, (int)requested_capacity);
                     state.db_mutexes[db_name] = std::make_unique<std::mutex>();
+
+                    if (state.meta) {
+                        state.meta->create_database(db_name, requested_dim,
+                            CoreEngine::IndexType::IVF, requested_capacity,
+                            *state.catalog[db_name]->get_header());
+                    }
                 }
 
                 active_db = state.catalog[db_name].get();
                 active_mtx = state.db_mutexes[db_name].get();
+                active_db_name = db_name;
             }
 
             if (active_db->get_dim() != requested_dim) {
@@ -211,9 +224,16 @@ void handle_client(int client_socket, SharedState& state) {
                         filename, requested_dim, (int)requested_capacity,
                         hnsw_M, hnsw_ef_construction);
                     state.db_mutexes[db_name] = std::make_unique<std::mutex>();
+
+                    if (state.meta) {
+                        state.meta->create_database(db_name, requested_dim,
+                            CoreEngine::IndexType::HNSW, requested_capacity,
+                            *state.catalog[db_name]->get_header());
+                    }
                 }
                 active_db = state.catalog[db_name].get();
                 active_mtx = state.db_mutexes[db_name].get();
+                active_db_name = db_name;
             }
 
             if (!send_all("1", 1)) break;
@@ -229,6 +249,10 @@ void handle_client(int client_socket, SharedState& state) {
             std::vector<float> vec(current_dim);
             if (!recv_all((char*)vec.data(), vec_byte_size)) break;
             { std::lock_guard<std::mutex> lk(*active_mtx); active_db->insert(meta_data, vec); }
+            if (state.meta) {
+                state.meta->update_counts(active_db_name, active_db->get_count(), active_db->get_next_id());
+                state.meta->log_operation(active_db_name, "INSERT", meta_data);
+            }
             if (!send_all("1", 1)) break;
         }
         else if (cmd == CMD_SEARCH) {
@@ -236,11 +260,18 @@ void handle_client(int client_socket, SharedState& state) {
             if (!recv_all((char*)query.data(), vec_byte_size)) break;
             int result_id;
             { std::lock_guard<std::mutex> lk(*active_mtx); result_id = active_db->search(query); }
+            if (state.meta) {
+                state.meta->log_operation(active_db_name, "SEARCH", 0);
+            }
             if (!send_all((char*)&result_id, 4)) break;
         }
         else if (cmd == CMD_DELETE) {
             bool success;
             { std::lock_guard<std::mutex> lk(*active_mtx); success = active_db->remove(meta_data); }
+            if (success && state.meta) {
+                state.meta->update_counts(active_db_name, active_db->get_count(), active_db->get_next_id());
+                state.meta->log_operation(active_db_name, "DELETE", meta_data);
+            }
             char resp = success ? '1' : '0';
             if (!send_all(&resp, 1)) break;
         }
@@ -249,6 +280,9 @@ void handle_client(int client_socket, SharedState& state) {
             if (!recv_all((char*)vec.data(), vec_byte_size)) break;
             bool success;
             { std::lock_guard<std::mutex> lk(*active_mtx); success = active_db->update(meta_data, vec); }
+            if (success && state.meta) {
+                state.meta->log_operation(active_db_name, "UPDATE", meta_data);
+            }
             char resp = success ? '1' : '0';
             if (!send_all(&resp, 1)) break;
         }
@@ -257,6 +291,10 @@ void handle_client(int client_socket, SharedState& state) {
             if (!recv_all((char*)vec.data(), vec_byte_size)) break;
             uint64_t assigned_id;
             { std::lock_guard<std::mutex> lk(*active_mtx); assigned_id = active_db->insert_auto(vec); }
+            if (state.meta) {
+                state.meta->update_counts(active_db_name, active_db->get_count(), active_db->get_next_id());
+                state.meta->log_operation(active_db_name, "INSERT_AUTO", assigned_id);
+            }
             if (!send_all((char*)&assigned_id, sizeof(assigned_id))) break;
         }
         else if (cmd == CMD_SEARCH_N) {
@@ -290,14 +328,16 @@ void handle_client(int client_socket, SharedState& state) {
                     }
                 }
                 if (!db_to_drop.empty()) {
-                    // Erase from catalog — unique_ptr destructor cleans up the engine
+                    if (state.meta) {
+                        state.meta->drop_database(db_to_drop);
+                    }
                     state.catalog.erase(db_to_drop);
                     state.db_mutexes.erase(db_to_drop);
-                    // Delete the .db file from disk
                     std::filesystem::remove(db_to_drop + ".db");
                     std::filesystem::remove(db_to_drop + ".db.del");
                     active_db  = nullptr;
                     active_mtx = nullptr;
+                    active_db_name.clear();
                     success    = true;
                 }
             }
@@ -322,6 +362,47 @@ void handle_client(int client_socket, SharedState& state) {
             }
             char resp = '1';
             if (!send_all(&resp, 1)) break;
+        }
+        else if (cmd == CMD_LIST_DBS) {
+            if (!state.meta) {
+                uint32_t count = 0;
+                if (!send_all((char*)&count, sizeof(count))) break;
+            } else {
+                std::vector<Metadata::DbInfo> dbs;
+                state.meta->list_databases(dbs);
+                uint32_t count = static_cast<uint32_t>(dbs.size());
+                if (!send_all((char*)&count, sizeof(count))) break;
+                for (auto& db : dbs) {
+                    uint8_t name_len = static_cast<uint8_t>(db.name.size());
+                    if (!send_all((char*)&name_len, 1)) break;
+                    if (!send_all(db.name.c_str(), name_len)) break;
+                    if (!send_all((char*)&db.dimensions, sizeof(db.dimensions))) break;
+                    uint8_t idx = static_cast<uint8_t>(db.index_type);
+                    if (!send_all((char*)&idx, 1)) break;
+                    if (!send_all((char*)&db.vector_count, sizeof(db.vector_count))) break;
+                }
+            }
+            continue;
+        }
+        else if (cmd == CMD_DB_INFO) {
+            if (!active_db || !state.meta) {
+                char zero = 0;
+                if (!send_all(&zero, 1)) break;
+            } else {
+                char ok = 1;
+                if (!send_all(&ok, 1)) break;
+                uint64_t vc = active_db->get_count();
+                uint64_t cap = active_db->get_header()->max_capacity;
+                uint64_t nid = active_db->get_next_id();
+                uint8_t idx = static_cast<uint8_t>(active_db->get_index_type());
+                uint32_t dim = active_db->get_dim();
+                if (!send_all((char*)&vc, sizeof(vc))) break;
+                if (!send_all((char*)&cap, sizeof(cap))) break;
+                if (!send_all((char*)&nid, sizeof(nid))) break;
+                if (!send_all((char*)&idx, 1)) break;
+                if (!send_all((char*)&dim, sizeof(dim))) break;
+            }
+            continue;
         }
         else {
             std::cerr << "[SERVER] Unknown cmd=" << (int)cmd << " — sending error response\n";
@@ -353,6 +434,54 @@ int main() {
 #endif
 
     SharedState state;
+
+    // --- PostgreSQL metadata store ---
+    const char* pg_host     = std::getenv("REDBOX_PG_HOST");
+    const char* pg_port     = std::getenv("REDBOX_PG_PORT");
+    const char* pg_dbname   = std::getenv("REDBOX_PG_DBNAME");
+    const char* pg_user     = std::getenv("REDBOX_PG_USER");
+    const char* pg_password = std::getenv("REDBOX_PG_PASSWORD");
+    const char* pg_data_dir = std::getenv("REDBOX_DATA_DIR");
+
+    std::string conninfo = "host=" + std::string(pg_host ? pg_host : "localhost")
+                         + " port=" + std::string(pg_port ? pg_port : "5432")
+                         + " dbname=" + std::string(pg_dbname ? pg_dbname : "redbox")
+                         + " user=" + std::string(pg_user ? pg_user : "redbox")
+                         + " password=" + std::string(pg_password ? pg_password : "");
+    std::string data_dir = pg_data_dir ? pg_data_dir : ".";
+
+    try {
+        state.meta = new Metadata::Store(conninfo, 8);
+        state.meta->run_migrations("sql/schema.sql");
+        state.meta->seed_from_files(data_dir);
+
+        // Hydrate in-memory catalog from PG
+        std::vector<Metadata::DbInfo> dbs;
+        state.meta->list_databases(dbs);
+        for (auto& db : dbs) {
+            CoreEngine::SpecificMetadata params;
+            state.meta->load_database(db.name, params);
+            std::string filename = data_dir + "/" + db.name + ".db";
+            std::lock_guard<std::mutex> lock(state.catalog_mutex);
+            if (params.index_type == static_cast<uint8_t>(CoreEngine::IndexType::HNSW)) {
+                state.catalog[db.name] = std::make_unique<CoreEngine::RedBoxVector>(
+                    filename, params.dimensions, (int)params.max_capacity,
+                    params.hnsw_M, params.hnsw_ef_construction);
+            } else {
+                state.catalog[db.name] = std::make_unique<CoreEngine::RedBoxVector>(
+                    filename, params.dimensions, (int)params.max_capacity,
+                    params.num_clusters, params.num_probes);
+            }
+            state.db_mutexes[db.name] = std::make_unique<std::mutex>();
+            std::cout << "[SERVER] Loaded DB from metadata: " << db.name
+                      << " (dim=" << db.dimensions << " count=" << db.vector_count << ")\n";
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[SERVER] Failed to connect to PostgreSQL: " << e.what() << "\n";
+        std::cerr << "[SERVER] Set REDBOX_PG_HOST, REDBOX_PG_PORT, REDBOX_PG_DBNAME, "
+                     "REDBOX_PG_USER, REDBOX_PG_PASSWORD env vars.\n";
+        return 1;
+    }
 
 #ifdef _WIN32
     SOCKET server_socket = socket(AF_INET, SOCK_STREAM, 0);
@@ -401,6 +530,7 @@ int main() {
     }
 
     closesocket(server_socket);
+    delete state.meta;
 #ifdef _WIN32
     WSACleanup();
 #endif
@@ -425,8 +555,18 @@ int main() {
 
 
     CMD ID    Name        META Field        Payload                              Server Response
-    1        INSERT        Vector ID        Raw Float Data(Dim�4 bytes)          1 (Ack)
-    2        SEARCH        (Ignored)        Raw Float Data (Dim�4 bytes)        Result ID (4 bytes)
+    1        INSERT        Vector ID        Raw Float Data(Dim*4 bytes)          1 (Ack)
+    2        SEARCH        (Ignored)        Raw Float Data (Dim*4 bytes)        Result ID (4 bytes)
     3        DELETE        Vector ID        (None)                               1 or 0 (Success/Fail)
     4        SELECT_DB     Name Length      Database Name (UTF-8 String)         1 (Ack)
+    5        UPDATE        Vector ID        Raw Float Data (Dim*4 bytes)        1 or 0 (Success/Fail)
+    6        INSERT_AUTO   (Ignored)        Raw Float Data (Dim*4 bytes)        Assigned ID (8 bytes)
+    7        SEARCH_N      N (count)        Raw Float Data (Dim*4 bytes)        Count(4) + IDs(4*N)
+    8        DROP_DB       (Ignored)        (None)                               1 or 0
+    9        SET_PROBES    Probe count      (None)                               1 (Ack)
+    10       CREATE_HNSW   Name Length      Name + Dim(4) + Cap(4) + M(1) +     1 (Ack)
+                                            ef_c(2)
+    11       SET_HNSW_EF   ef value         (None)                               1 (Ack)
+    12       LIST_DBS      (Ignored)        (None)                               Count(4) + Entries
+    13       DB_INFO       (Ignored)        (None)                               OK(1) + VC(8)+Cap(8)+NID(8)+Type(1)+Dim(4)
 */

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -435,52 +435,54 @@ int main() {
 
     SharedState state;
 
-    // --- PostgreSQL metadata store ---
+    // --- PostgreSQL metadata store (optional) ---
     const char* pg_host     = std::getenv("REDBOX_PG_HOST");
     const char* pg_port     = std::getenv("REDBOX_PG_PORT");
     const char* pg_dbname   = std::getenv("REDBOX_PG_DBNAME");
     const char* pg_user     = std::getenv("REDBOX_PG_USER");
     const char* pg_password = std::getenv("REDBOX_PG_PASSWORD");
     const char* pg_data_dir = std::getenv("REDBOX_DATA_DIR");
-
-    std::string conninfo = "host=" + std::string(pg_host ? pg_host : "localhost")
-                         + " port=" + std::string(pg_port ? pg_port : "5432")
-                         + " dbname=" + std::string(pg_dbname ? pg_dbname : "redbox")
-                         + " user=" + std::string(pg_user ? pg_user : "redbox")
-                         + " password=" + std::string(pg_password ? pg_password : "");
     std::string data_dir = pg_data_dir ? pg_data_dir : ".";
 
-    try {
-        state.meta = new Metadata::Store(conninfo, 8);
-        state.meta->run_migrations("sql/schema.sql");
-        state.meta->seed_from_files(data_dir);
+    if (pg_host && pg_host[0] != '\0') {
+        std::string conninfo = "host=" + std::string(pg_host)
+                             + " port=" + std::string(pg_port ? pg_port : "5432")
+                             + " dbname=" + std::string(pg_dbname ? pg_dbname : "redbox")
+                             + " user=" + std::string(pg_user ? pg_user : "redbox")
+                             + " password=" + std::string(pg_password ? pg_password : "");
+        try {
+            state.meta = new Metadata::Store(conninfo, 8);
+            state.meta->run_migrations("sql/schema.sql");
+            state.meta->seed_from_files(data_dir);
 
-        // Hydrate in-memory catalog from PG
-        std::vector<Metadata::DbInfo> dbs;
-        state.meta->list_databases(dbs);
-        for (auto& db : dbs) {
-            CoreEngine::SpecificMetadata params;
-            state.meta->load_database(db.name, params);
-            std::string filename = data_dir + "/" + db.name + ".db";
-            std::lock_guard<std::mutex> lock(state.catalog_mutex);
-            if (params.index_type == static_cast<uint8_t>(CoreEngine::IndexType::HNSW)) {
-                state.catalog[db.name] = std::make_unique<CoreEngine::RedBoxVector>(
-                    filename, params.dimensions, (int)params.max_capacity,
-                    params.hnsw_M, params.hnsw_ef_construction);
-            } else {
-                state.catalog[db.name] = std::make_unique<CoreEngine::RedBoxVector>(
-                    filename, params.dimensions, (int)params.max_capacity,
-                    params.num_clusters, params.num_probes);
+            std::vector<Metadata::DbInfo> dbs;
+            state.meta->list_databases(dbs);
+            for (auto& db : dbs) {
+                CoreEngine::SpecificMetadata params;
+                state.meta->load_database(db.name, params);
+                std::string filename = data_dir + "/" + db.name + ".db";
+                std::lock_guard<std::mutex> lock(state.catalog_mutex);
+                if (params.index_type == static_cast<uint8_t>(CoreEngine::IndexType::HNSW)) {
+                    state.catalog[db.name] = std::make_unique<CoreEngine::RedBoxVector>(
+                        filename, params.dimensions, (int)params.max_capacity,
+                        params.hnsw_M, params.hnsw_ef_construction);
+                } else {
+                    state.catalog[db.name] = std::make_unique<CoreEngine::RedBoxVector>(
+                        filename, params.dimensions, (int)params.max_capacity,
+                        params.num_clusters, params.num_probes);
+                }
+                state.db_mutexes[db.name] = std::make_unique<std::mutex>();
+                std::cout << "[SERVER] Loaded DB from metadata: " << db.name
+                          << " (dim=" << db.dimensions << " count=" << db.vector_count << ")\n";
             }
-            state.db_mutexes[db.name] = std::make_unique<std::mutex>();
-            std::cout << "[SERVER] Loaded DB from metadata: " << db.name
-                      << " (dim=" << db.dimensions << " count=" << db.vector_count << ")\n";
+            std::cout << "[SERVER] PostgreSQL metadata store connected.\n";
+        } catch (const std::exception& e) {
+            std::cerr << "[SERVER] WARNING: Failed to connect to PostgreSQL: " << e.what() << "\n";
+            std::cerr << "[SERVER] Running without metadata persistence.\n";
+            state.meta = nullptr;
         }
-    } catch (const std::exception& e) {
-        std::cerr << "[SERVER] Failed to connect to PostgreSQL: " << e.what() << "\n";
-        std::cerr << "[SERVER] Set REDBOX_PG_HOST, REDBOX_PG_PORT, REDBOX_PG_DBNAME, "
-                     "REDBOX_PG_USER, REDBOX_PG_PASSWORD env vars.\n";
-        return 1;
+    } else {
+        std::cout << "[SERVER] REDBOX_PG_HOST not set. Running without metadata persistence.\n";
     }
 
 #ifdef _WIN32

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,14 @@
-add_executable(RedBoxDbTests
+set(TEST_SOURCES
     test_main.cpp
     test_hnsw.cpp
     test_extended.cpp
-    test_metadata_store.cpp
 )
+
+if(REDBOX_ENABLE_PG)
+    list(APPEND TEST_SOURCES test_metadata_store.cpp)
+endif()
+
+add_executable(RedBoxDbTests ${TEST_SOURCES})
 
 target_compile_definitions(RedBoxDbTests PRIVATE REDBOX_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
@@ -13,9 +18,11 @@ target_link_libraries(RedBoxDbTests
         gtest_main
         RedBoxDbLib
         spdlog::spdlog
-        pqxx
-        PostgreSQL::PostgreSQL
 )
+
+if(REDBOX_ENABLE_PG)
+    target_link_libraries(RedBoxDbTests PRIVATE pqxx PostgreSQL::PostgreSQL)
+endif()
 
 set_project_warnings(RedBoxDbTests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,8 @@ add_executable(RedBoxDbTests
     test_metadata_store.cpp
 )
 
+target_compile_definitions(RedBoxDbTests PRIVATE REDBOX_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+
 target_link_libraries(RedBoxDbTests
     PRIVATE
         gtest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(RedBoxDbTests
     test_main.cpp
     test_hnsw.cpp
     test_extended.cpp
+    test_metadata_store.cpp
 )
 
 target_link_libraries(RedBoxDbTests
@@ -10,6 +11,8 @@ target_link_libraries(RedBoxDbTests
         gtest_main
         RedBoxDbLib
         spdlog::spdlog
+        pqxx
+        PostgreSQL::PostgreSQL
 )
 
 set_project_warnings(RedBoxDbTests)

--- a/tests/test_metadata_store.cpp
+++ b/tests/test_metadata_store.cpp
@@ -40,7 +40,8 @@ protected:
             GTEST_SKIP() << "PostgreSQL not available (set REDBOX_PG_* env vars)";
         }
         store = std::make_unique<Metadata::Store>(get_pg_conninfo(), 2);
-        store->run_migrations("sql/schema.sql");
+        std::string schema_path = std::string(REDBOX_SOURCE_DIR) + "/sql/schema.sql";
+        store->run_migrations(schema_path);
     }
 
     static void TearDownTestSuite() {

--- a/tests/test_metadata_store.cpp
+++ b/tests/test_metadata_store.cpp
@@ -1,0 +1,203 @@
+#include <gtest/gtest.h>
+#include "redboxdb/metadata_store.hpp"
+#include "redboxdb/SpecificMetadata.hpp"
+#include <cstdlib>
+#include <filesystem>
+#include <fcntl.h>
+#include <unistd.h>
+
+static std::string get_pg_conninfo() {
+    const char* host = std::getenv("REDBOX_PG_HOST");
+    const char* port = std::getenv("REDBOX_PG_PORT");
+    const char* db   = std::getenv("REDBOX_PG_DBNAME");
+    const char* user = std::getenv("REDBOX_PG_USER");
+    const char* pass = std::getenv("REDBOX_PG_PASSWORD");
+
+    return "host=" + std::string(host ? host : "localhost")
+         + " port=" + std::string(port ? port : "5432")
+         + " dbname=" + std::string(db ? db : "redbox_test")
+         + " user=" + std::string(user ? user : "redbox")
+         + " password=" + std::string(pass ? pass : "test");
+}
+
+static bool pg_available() {
+    try {
+        Metadata::Store test(get_pg_conninfo(), 1);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+class MetadataStoreTest : public ::testing::Test {
+protected:
+    static std::unique_ptr<Metadata::Store> store;
+    static bool pg_ok;
+
+    static void SetUpTestSuite() {
+        pg_ok = pg_available();
+        if (!pg_ok) {
+            GTEST_SKIP() << "PostgreSQL not available (set REDBOX_PG_* env vars)";
+        }
+        store = std::make_unique<Metadata::Store>(get_pg_conninfo(), 2);
+        store->run_migrations("sql/schema.sql");
+    }
+
+    static void TearDownTestSuite() {
+        if (store) {
+            store.reset();
+        }
+    }
+};
+
+std::unique_ptr<Metadata::Store> MetadataStoreTest::store = nullptr;
+bool MetadataStoreTest::pg_ok = false;
+
+TEST_F(MetadataStoreTest, CreateDatabase) {
+    CoreEngine::SpecificMetadata params{};
+    params.vector_count = 0;
+    params.max_capacity = 10000;
+    params.dimensions = 128;
+    params.next_id = 1;
+
+    store->create_database("test_create", 128, CoreEngine::IndexType::IVF, 10000, params);
+
+    CoreEngine::SpecificMetadata loaded{};
+    store->load_database("test_create", loaded);
+
+    EXPECT_EQ(loaded.dimensions, 128u);
+    EXPECT_EQ(loaded.max_capacity, 10000u);
+    EXPECT_EQ(loaded.vector_count, 0u);
+}
+
+TEST_F(MetadataStoreTest, CreateHnswDatabase) {
+    CoreEngine::SpecificMetadata params{};
+    params.vector_count = 0;
+    params.max_capacity = 5000;
+    params.dimensions = 64;
+    params.next_id = 1;
+    params.hnsw_M = 16;
+    params.hnsw_ef_construction = 200;
+    params.hnsw_ef_search = 256;
+    params.hnsw_max_level = 16;
+    params.index_type = static_cast<uint8_t>(CoreEngine::IndexType::HNSW);
+
+    store->create_database("test_hnsw", 64, CoreEngine::IndexType::HNSW, 5000, params);
+
+    CoreEngine::SpecificMetadata loaded{};
+    store->load_database("test_hnsw", loaded);
+
+    EXPECT_EQ(loaded.dimensions, 64u);
+    EXPECT_EQ(loaded.hnsw_M, 16);
+    EXPECT_EQ(loaded.hnsw_ef_construction, 200);
+    EXPECT_EQ(loaded.index_type, static_cast<uint8_t>(CoreEngine::IndexType::HNSW));
+}
+
+TEST_F(MetadataStoreTest, UpdateCounts) {
+    CoreEngine::SpecificMetadata params{};
+    params.dimensions = 128;
+    params.max_capacity = 10000;
+    params.vector_count = 0;
+    params.next_id = 1;
+
+    store->create_database("test_counts", 128, CoreEngine::IndexType::IVF, 10000, params);
+    store->update_counts("test_counts", 42, 43);
+
+    CoreEngine::SpecificMetadata loaded{};
+    store->load_database("test_counts", loaded);
+
+    EXPECT_EQ(loaded.vector_count, 42u);
+    EXPECT_EQ(loaded.next_id, 43u);
+}
+
+TEST_F(MetadataStoreTest, UpdateHnswState) {
+    CoreEngine::SpecificMetadata params{};
+    params.dimensions = 128;
+    params.max_capacity = 10000;
+    params.vector_count = 0;
+    params.next_id = 1;
+    params.hnsw_M = 16;
+    params.hnsw_ef_construction = 200;
+    params.index_type = static_cast<uint8_t>(CoreEngine::IndexType::HNSW);
+
+    store->create_database("test_hnsw_state", 128, CoreEngine::IndexType::HNSW, 10000, params);
+    store->update_hnsw_state("test_hnsw_state", 5, 3);
+
+    CoreEngine::SpecificMetadata loaded{};
+    store->load_database("test_hnsw_state", loaded);
+
+    EXPECT_EQ(loaded.hnsw_entry_point, 5u);
+    EXPECT_EQ(loaded.hnsw_graph_version, 3u);
+}
+
+TEST_F(MetadataStoreTest, ListDatabases) {
+    std::vector<Metadata::DbInfo> dbs;
+    store->list_databases(dbs);
+
+    EXPECT_GE(dbs.size(), 2u);
+
+    bool found_create = false, found_hnsw = false;
+    for (auto& d : dbs) {
+        if (d.name == "test_create") found_create = true;
+        if (d.name == "test_hnsw") found_hnsw = true;
+    }
+    EXPECT_TRUE(found_create);
+    EXPECT_TRUE(found_hnsw);
+}
+
+TEST_F(MetadataStoreTest, DropDatabase) {
+    CoreEngine::SpecificMetadata params{};
+    params.dimensions = 32;
+    params.max_capacity = 1000;
+    params.vector_count = 0;
+    params.next_id = 1;
+
+    store->create_database("test_drop", 32, CoreEngine::IndexType::IVF, 1000, params);
+    store->drop_database("test_drop");
+
+    EXPECT_THROW(store->load_database("test_drop", params), std::exception);
+}
+
+TEST_F(MetadataStoreTest, AuditLog) {
+    store->log_operation("test_create", "INSERT", 1);
+    store->log_operation("test_create", "SEARCH", 0);
+    store->log_operation("test_create", "DELETE", 1);
+
+    std::vector<Metadata::DbInfo> dbs;
+    store->list_databases(dbs);
+
+    EXPECT_GE(dbs.size(), 1u);
+}
+
+TEST_F(MetadataStoreTest, SeedFromFiles) {
+    std::string tmp_dir = "/tmp/redbox_meta_test";
+    std::filesystem::create_directories(tmp_dir);
+
+    std::string db_path = tmp_dir + "/test_seed.db";
+    int fd = open(db_path.c_str(), O_RDWR | O_CREAT, 0644);
+    ASSERT_GE(fd, 0);
+
+    CoreEngine::SpecificMetadata header{};
+    header.dimensions = 64;
+    header.max_capacity = 500;
+    header.vector_count = 10;
+    header.next_id = 11;
+    header.index_type = static_cast<uint8_t>(CoreEngine::IndexType::IVF);
+
+    ssize_t wr = write(fd, &header, sizeof(header));
+    EXPECT_EQ(wr, (ssize_t)sizeof(header));
+    int tr = ftruncate(fd, sizeof(header));
+    EXPECT_EQ(tr, 0);
+    close(fd);
+
+    store->seed_from_files(tmp_dir);
+
+    CoreEngine::SpecificMetadata loaded{};
+    store->load_database("test_seed", loaded);
+
+    EXPECT_EQ(loaded.dimensions, 64u);
+    EXPECT_EQ(loaded.vector_count, 10u);
+
+    store->drop_database("test_seed");
+    std::filesystem::remove_all(tmp_dir);
+}


### PR DESCRIPTION
## PostgreSQL Metadata Store + Benchmark CI Fix

### PostgreSQL Metadata Store
- **libpqxx 8.0.2** via FetchContent for PostgreSQL integration
- **`Metadata::Store`** class: single pqxx::connection + std::mutex (pqxx 8.0.2 removed connection_pool)
- **`sql/schema.sql`**: databases, audit_log, server_config tables with proper indexes
- **Catalog seeding**: scans existing `.db` files via mmap to bootstrap PG on first startup
- **Runtime hydration**: in-memory state restored from PG on server start
- **Metadata sync**: every INSERT/DELETE/UPDATE operation writes to PG + audit_log
- **New protocol commands**: CMD 12 (LIST_DBS), CMD 13 (DB_INFO)
- **Python client**: `list_databases()`, `database_info()` methods
- **8 integration tests**: skip gracefully when PG unavailable
- **CI**: PostgreSQL 16 service + libpq-dev on Linux

### Benchmark CI Fix
- `ci_bench.py` gains `prepare` mode for CI (updates files without git commit)
- `gh pr merge --auto --squash` made non-fatal (auto-merge not enabled in repo settings)
- `gh pr comment` made non-fatal for fork PRs ("Resource not accessible by integration")
- Workflow creates branch → commit → push → PR (avoids direct-to-master commit issues)

### Configuration
Environment variables: `REDBOX_PG_HOST`, `REDBOX_PG_PORT`, `REDBOX_PG_DBNAME`, `REDBOX_PG_USER`, `REDBOX_PG_PASSWORD`, `REDBOX_DATA_DIR`
