### PR TITLE
Fix strict-aliasing violation in warm_pages()

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -511,11 +511,18 @@ namespace CoreEngine {
         volatile uint64_t sink = 0;
         size_t cap = _manager->get_header()->max_capacity;
 
-        // Touch every vector (float_block) — 4KB stride = page
+        // Touch every vector (float_block) — 4KB stride = page.
+        // Read via memcpy into a local, not a reinterpret_cast'd dereference:
+        // aliasing a float* as a uint64_t* violates strict aliasing, which
+        // lets the compiler assume the read can't observe writes through the
+        // float pointer and reorder or drop it. memcpy's byte-level copy is
+        // exempt from strict aliasing and is guaranteed to happen.
         const float* fblk = _manager->get_float_ptr(0);
         size_t dim = dimension;
         for (size_t i = 0; i < cap; ++i) {
-            sink += *reinterpret_cast<const uint64_t*>(&fblk[i * dim]);
+            uint64_t chunk;
+            std::memcpy(&chunk, &fblk[i * dim], sizeof(chunk));
+            sink += chunk;
         }
 
         // Touch every edge entry
@@ -524,7 +531,9 @@ namespace CoreEngine {
             uint8_t M = _manager->get_header()->hnsw_M;
             size_t epn = HnswManager::edges_per_node(M);
             for (size_t i = 0; i < cap; ++i) {
-                sink += *reinterpret_cast<const uint64_t*>(&eblk[i * epn]);
+                uint64_t chunk;
+                std::memcpy(&chunk, &eblk[i * epn], sizeof(chunk));
+                sink += chunk;
             }
         }
 


### PR DESCRIPTION
Closes #83

## Problem

`warm_pages()` read each vector's / edge-block's bytes as a `uint64_t` via `reinterpret_cast<const uint64_t*>(&fblk[...])` / `reinterpret_cast<const uint64_t*>(&eblk[...])`, dereferencing a `float*`/`uint32_t*` through a `uint64_t*` lvalue. That violates C++ strict aliasing — the compiler is entitled to assume a `uint64_t` read can't alias a `float`/`uint32_t` write, since they're unrelated types — which means the **read itself**, not just the accumulation into `sink`, could be reordered or eliminated at `-O2`, defeating the whole point of `warm_pages()` (touching every page to fault it into the OS page cache before latency-sensitive work starts).

`sink` was already declared `volatile`, which forces the *write* side to happen, but that doesn't fix the *read* side's aliasing UB.

## Fix

`std::memcpy` the same 8 bytes into a local `uint64_t` instead of a type-punned dereference. `memcpy` operates at the unsigned-char level, which is explicitly exempt from strict aliasing, so this is guaranteed well-defined and can't be optimized away by the compiler assuming non-aliasing. Same bytes read, same accumulation into `sink` — only the read mechanism changes.

## Verification

This machine's C++ toolchain is missing standard library headers (even a bare `#include <iostream>` fails `-fsyntax-only`), so I could not compile this locally. What I did verify:
- `cmake -S . -B build -DREDBOX_ENABLE_PG=OFF` configures cleanly (unaffected by this change — single function body edit, no new includes needed, `<cstring>` was already included).
- Reviewed by hand: `dim` / `edges_per_node(M)` are always ≥ 2 in practice (real vector dimensions and HNSW node degrees are far larger than the 2×4-byte elements needed for an 8-byte `memcpy`), matching the same implicit assumption the original code already made.

CI should be the real verification here — happy to iterate on anything that doesn't hold up once it actually builds.