### PR TITLE
Fix O(n^2) byte concatenation in _recv_exact

### DIFF
--- a/Client/client.py
+++ b/Client/client.py
@@ -53,13 +53,13 @@ class RedBoxClient:
             raise RuntimeError("Server rejected handshake or disconnected.")
 
     def _recv_exact(self, n: int) -> bytes:
-        buf = b''
+        buf = bytearray()
         while len(buf) < n:
             chunk = self.sock.recv(n - len(buf))
             if not chunk:
                 raise ConnectionError("Server disconnected mid-response")
-            buf += chunk
-        return buf
+            buf.extend(chunk)
+        return bytes(buf)
 
     def _validate_vector(self, vector: Union[np.ndarray, List[float]]) -> bytes:
         if isinstance(vector, list):

--- a/Client/test_client.py
+++ b/Client/test_client.py
@@ -1,0 +1,51 @@
+"""
+Unit tests for RedBoxClient's wire-protocol helpers, using a fake socket
+so they run without a live RedBoxDb server.
+"""
+import unittest
+
+from client import RedBoxClient
+
+
+class FakeSocket:
+    """Minimal stand-in for socket.socket: recv() returns pre-scripted chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def recv(self, n):
+        if not self._chunks:
+            return b""
+        chunk = self._chunks.pop(0)
+        return chunk[:n]
+
+
+def make_client_with_socket(sock):
+    client = RedBoxClient.__new__(RedBoxClient)
+    client.sock = sock
+    return client
+
+
+class TestRecvExact(unittest.TestCase):
+    def test_assembles_response_across_multiple_chunks(self):
+        client = make_client_with_socket(FakeSocket([b"ab", b"cd", b"ef"]))
+
+        result = client._recv_exact(6)
+
+        self.assertEqual(result, b"abcdef")
+        self.assertIsInstance(result, bytes)
+
+    def test_single_chunk_response(self):
+        client = make_client_with_socket(FakeSocket([b"hello"]))
+
+        self.assertEqual(client._recv_exact(5), b"hello")
+
+    def test_raises_connection_error_when_server_disconnects_mid_response(self):
+        client = make_client_with_socket(FakeSocket([b"ab", b""]))
+
+        with self.assertRaises(ConnectionError):
+            client._recv_exact(6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #94

## Problem

`_recv_exact()` built the response buffer via `buf += chunk` on a `bytes` object. `bytes` is immutable, so `+=` reallocates and copies the *entire* buffer on every iteration — O(n²) total work for an n-byte response assembled over many small `recv()` calls (e.g. `search_N` with a large N).

## Fix

Switched to `bytearray` + `.extend()`, which appends in place (amortized O(1) per call, O(n) total), converting to `bytes` once at the end so the return type is unchanged for callers (`struct.unpack` etc.).

## Testing

There was no test infrastructure for the Python client at all, so added `Client/test_client.py` with a `FakeSocket` that returns scripted `recv()` chunks (no live server needed): multi-chunk assembly, single-chunk response, and the existing disconnect-mid-response `ConnectionError` behavior — all pass under the new implementation. Ran locally with `python3 -m unittest test_client -v`: 3/3 pass.