### PR TITLE
Add socket timeout to Python client

### DIFF
--- a/Client/client.py
+++ b/Client/client.py
@@ -23,12 +23,13 @@ class RedBoxClient:
     CMD_CREATE_HNSW_DB = 10
     CMD_SET_HNSW_EF = 11
 
-    def __init__(self, host: str = '127.0.0.1', port: int = 8080, db_name: str = 'default', dim: int = 128, capacity: int=100_000):
+    def __init__(self, host: str = '127.0.0.1', port: int = 8080, db_name: str = 'default', dim: int = 128, capacity: int=100_000, timeout: float = 30.0):
         self.host    = host
         self.port    = port
         self.dim     = dim
         self.db_name = db_name
         self.capacity = capacity
+        self.timeout = timeout
         self.sock: Optional[socket.socket] = None
 
         self._connect()
@@ -38,10 +39,13 @@ class RedBoxClient:
     def _connect(self):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self.sock.settimeout(self.timeout)
         try:
             self.sock.connect((self.host, self.port))
         except ConnectionRefusedError:
             raise ConnectionError(f"Could not connect to RedBoxDb at {self.host}:{self.port}. Is the server running?")
+        except socket.timeout:
+            raise ConnectionError(f"Timed out connecting to RedBoxDb at {self.host}:{self.port} after {self.timeout}s.")
 
     def _handshake(self, name: str, dim: int, capacity: int):
         name_bytes = name.encode('utf-8')
@@ -136,7 +140,8 @@ class RedBoxClient:
     def create_hnsw(cls, host: str = '127.0.0.1', port: int = 8080,
                     db_name: str = 'default', dim: int = 128,
                     capacity: int = 100_000,
-                    hnsw_M: int = 16, hnsw_ef_construction: int = 200):
+                    hnsw_M: int = 16, hnsw_ef_construction: int = 200,
+                    timeout: float = 30.0):
         """Create a new client connected to an HNSW database."""
         client = cls.__new__(cls)
         client.host = host
@@ -144,6 +149,7 @@ class RedBoxClient:
         client.dim = dim
         client.db_name = db_name
         client.capacity = capacity
+        client.timeout = timeout
         client.sock = None
 
         client._connect()

--- a/Client/test_client_timeout.py
+++ b/Client/test_client_timeout.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for RedBoxClient socket timeout behavior (issue #91).
+
+Uses a real local TCP listener that accepts connections but never sends
+data, to prove the client actually times out instead of hanging forever --
+not just that settimeout() is called somewhere.
+"""
+import socket
+import threading
+import time
+import unittest
+
+from client import RedBoxClient
+
+
+class _SilentServer:
+    """Accepts TCP connections and then never sends or closes -- simulates
+    an unresponsive server for timeout testing."""
+
+    def __init__(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        self._stop = False
+        self._accepted = []
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._thread.start()
+
+    def _accept_loop(self):
+        self._sock.settimeout(0.1)
+        while not self._stop:
+            try:
+                conn, _ = self._sock.accept()
+                self._accepted.append(conn)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+    def close(self):
+        self._stop = True
+        self._thread.join(timeout=2)
+        for conn in self._accepted:
+            conn.close()
+        self._sock.close()
+
+
+class TestClientTimeout(unittest.TestCase):
+    def setUp(self):
+        self.server = _SilentServer()
+
+    def tearDown(self):
+        self.server.close()
+
+    def test_handshake_times_out_instead_of_hanging_forever(self):
+        start = time.monotonic()
+        with self.assertRaises((socket.timeout, TimeoutError, ConnectionError)):
+            RedBoxClient(host="127.0.0.1", port=self.server.port, timeout=0.3)
+        elapsed = time.monotonic() - start
+
+        # Bounded well below what "hangs forever" would look like in a test run.
+        self.assertLess(elapsed, 5.0)
+
+    def test_default_timeout_is_thirty_seconds(self):
+        client = RedBoxClient.__new__(RedBoxClient)
+        client.host = "127.0.0.1"
+        client.port = self.server.port
+        client.timeout = 30.0
+        client.sock = None
+        client._connect()
+        try:
+            self.assertEqual(client.sock.gettimeout(), 30.0)
+        finally:
+            client.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #91

## Problem

Neither `_connect()` nor any `recv()` call set a socket timeout, so a server that accepts a connection but never responds (or stops responding mid-session) caused the client to hang indefinitely.

## Fix

Added a `timeout: float = 30.0` parameter to `__init__()` and `create_hnsw()` (both construct the socket via `_connect()`), stored on the instance and applied via `sock.settimeout()` before `connect()` — so both the initial TCP connect and every subsequent `recv()` are bounded. A connect-phase timeout now raises the same `ConnectionError` callers already handle for connection-refused, rather than a bare `socket.timeout`.

## Testing

Verified with a real local TCP listener (`Client/test_client_timeout.py`) that accepts connections but never sends data or closes — proving the client actually times out instead of hanging, not just that `settimeout()` is called somewhere.

Confirmed the new tests fail against the pre-fix code (`TypeError: unexpected keyword argument 'timeout'`, and `gettimeout()` returns `None` instead of `30.0`) — checked via `git stash`, run through a bounded subprocess so a genuine hang couldn't block the verification itself — and pass with the fix.

Named `test_client_timeout.py` (not `test_client.py`) so this stays independently mergeable alongside #94, which adds its own new `Client/test_client.py`.