### PR TITLE
Close socket on failed handshake, in both constructors

### DIFF
--- a/Client/client.py
+++ b/Client/client.py
@@ -31,8 +31,12 @@ class RedBoxClient:
         self.capacity = capacity
         self.sock: Optional[socket.socket] = None
 
-        self._connect()
-        self._handshake(db_name, dim, capacity)
+        try:
+            self._connect()
+            self._handshake(db_name, dim, capacity)
+        except Exception:
+            self.close()
+            raise
 
 
     def _connect(self):
@@ -146,8 +150,12 @@ class RedBoxClient:
         client.capacity = capacity
         client.sock = None
 
-        client._connect()
-        client._handshake_hnsw(db_name, dim, capacity, hnsw_M, hnsw_ef_construction)
+        try:
+            client._connect()
+            client._handshake_hnsw(db_name, dim, capacity, hnsw_M, hnsw_ef_construction)
+        except Exception:
+            client.close()
+            raise
         return client
 
     def _handshake_hnsw(self, name: str, dim: int, capacity: int, hnsw_M: int, hnsw_ef_construction: int):

--- a/Client/test_client_handshake_cleanup.py
+++ b/Client/test_client_handshake_cleanup.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for socket cleanup on failed handshake (issue #92).
+
+Uses a real local TCP listener that accepts the connection and then
+closes it immediately without sending an ack, reproducing "the server
+rejected the handshake" against real sockets rather than a mock.
+"""
+import socket
+import threading
+import unittest
+import unittest.mock
+
+from client import RedBoxClient
+
+
+class _RejectingServer:
+    """Accepts a TCP connection, then closes it without sending anything."""
+
+    def __init__(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        self._stop = False
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._thread.start()
+
+    def _accept_loop(self):
+        self._sock.settimeout(0.1)
+        while not self._stop:
+            try:
+                conn, _ = self._sock.accept()
+                conn.close()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+    def close(self):
+        self._stop = True
+        self._thread.join(timeout=2)
+        self._sock.close()
+
+
+class TestSocketCleanupOnFailedHandshake(unittest.TestCase):
+    def setUp(self):
+        self.server = _RejectingServer()
+        self.opened_sockets = []
+        original_connect = RedBoxClient._connect
+
+        def _tracking_connect(client_self):
+            original_connect(client_self)
+            self.opened_sockets.append(client_self.sock)
+
+        self._patch = unittest.mock.patch.object(RedBoxClient, "_connect", _tracking_connect)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        self.server.close()
+
+    def test_socket_is_closed_when_handshake_fails(self):
+        # An immediate server-side close can surface as a graceful b'' read
+        # (RuntimeError, per _handshake's own check) or as a TCP RST
+        # (ConnectionResetError) depending on OS/timing -- either way, the
+        # socket must not leak.
+        with self.assertRaises((RuntimeError, ConnectionError, OSError)):
+            RedBoxClient(host="127.0.0.1", port=self.server.port, db_name="x", dim=3)
+
+        self.assertEqual(len(self.opened_sockets), 1)
+        # fileno() is -1 on a closed socket -- the documented, portable way
+        # to check, since close() is idempotent and doesn't always raise.
+        self.assertEqual(self.opened_sockets[0].fileno(), -1)
+
+    def test_create_hnsw_closes_socket_when_handshake_fails(self):
+        # An immediate server-side close can surface as a graceful b'' read
+        # (RuntimeError, per _handshake's own check) or as a TCP RST
+        # (ConnectionResetError) depending on OS/timing -- either way, the
+        # socket must not leak.
+        with self.assertRaises((RuntimeError, ConnectionError, OSError)):
+            RedBoxClient.create_hnsw(host="127.0.0.1", port=self.server.port, db_name="x", dim=3)
+
+        self.assertEqual(len(self.opened_sockets), 1)
+        self.assertEqual(self.opened_sockets[0].fileno(), -1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #92

## Problem

If `_handshake()` raised after `_connect()` had opened a socket, the socket was never closed — `__init__` had no try/finally guard. Over repeated failed connection attempts (wrong dim, server rejecting the DB name, etc.) file descriptors leak.

## Fix

Wrapped `_connect()` + `_handshake()` in `__init__` in try/except, closing the socket via the existing `close()` method before re-raising. Applied the identical fix to `create_hnsw()` (classmethod), which has the exact same `_connect()` + `_handshake_hnsw()` pattern and the exact same bug — the issue only cited `__init__`'s line numbers, but leaving the classmethod broken would just be the same leak via a different entry point.

## Testing

Verified with a real local TCP listener (`Client/test_client_handshake_cleanup.py`) that accepts a connection and closes it immediately without an ack, tracking the actual socket object `_connect()` creates and asserting its `fileno()` is `-1` (closed) after the expected failure.

Confirmed via `git stash` that both tests fail against the pre-fix code (`fileno()` is a real open fd, `4`/`5`, not `-1`) and pass with the fix.

**Note**: on this platform, an immediate server-side close surfaces as `ConnectionResetError` (TCP RST) rather than the `b''` read the issue describes — tests assert against `RuntimeError`, `ConnectionError`, or `OSError` generally, since `__init__`'s `except Exception` correctly closes the socket either way regardless of which specific error the OS happens to surface.

This overlaps slightly with #91 (both touch `_connect()`/`__init__`) — kept independently mergeable; happy to rebase if needed.