### PR TITLE
Run VerifyHnsw in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,21 @@ jobs:
         cd build/tests
         ./RedBoxDbTests
 
+    # 7b. Run HNSW performance/recall verification (insert throughput, QPS,
+    # recall@K -- see tests/verify_hnsw.cpp for thresholds). Exits non-zero
+    # if any threshold isn't met, so this gates CI like the GTest step above.
+    - name: Run HNSW Verification (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        cd build/tests
+        if (Test-Path VerifyHnsw.exe) { .\VerifyHnsw.exe }
+
+    - name: Run HNSW Verification (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        cd build/tests
+        ./VerifyHnsw
+
     # 8. Run Python Integration Tests
     - name: Run System Verification (Windows)
       if: runner.os == 'Windows'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,3 +47,8 @@ set_project_warnings(VerifyHnsw)
 # Register tests with CTest (Standard CMake testing tool)
 include(GoogleTest)
 gtest_discover_tests(RedBoxDbTests)
+
+# VerifyHnsw exits 0 when insert throughput, QPS, and recall are all above
+# threshold (see tests/verify_hnsw.cpp), non-zero otherwise -- CTest reads
+# that directly as pass/fail.
+add_test(NAME VerifyHnsw COMMAND VerifyHnsw)


### PR DESCRIPTION
Closes #104

## Problem

`VerifyHnsw` is a standalone executable with pass/fail thresholds (insert throughput ≥ 1500 vecs/sec, QPS ≥ 1500, recall@K ≥ 85% — see `tests/verify_hnsw.cpp`) that exits non-zero if any threshold isn't met. CI only ran `RedBoxDbTests` (GTest), so HNSW performance regressions went completely undetected.

## Fix

- `tests/CMakeLists.txt`: registered it with CTest (`add_test(NAME VerifyHnsw COMMAND VerifyHnsw)`).
- `.github/workflows/ci.yml`: added explicit "Run HNSW Verification" steps for both Windows and Linux, placed right after the existing GTest step and mirroring its exact style (including the Windows `Test-Path` existence guard the GTest step already uses).

## Note for the maintainer

The insert-throughput and QPS thresholds are wall-clock performance numbers on whatever hardware CI happens to run on. On a shared/throttled runner these could plausibly be flakier than the recall check (which is a correctness/algorithmic measure, not timing-based). I implemented this as a real, enforcing CI gate since that's what the issue asks for ("regressions go undetected"), but flagging this now in case you'd rather soften the CI-specific thresholds or mark this step `continue-on-error` after seeing how it behaves on real runner hardware — that's not something I can observe from here.

## Testing

- `actionlint`'s shellcheck findings only increased by the same pre-existing false-positive count already present for the GTest Windows step (PowerShell's `if (Test-Path X) { Y }` misparsed as bash): 18 findings on unmodified `master`, 21 after this change — all 3 new ones the same already-accepted `SC1050`/`SC1072`/`SC1073` pattern, not a new class of issue.
- `cmake -S . -B build -DREDBOX_ENABLE_PG=OFF` configures cleanly with the new `add_test()` call.
- Could not actually run `VerifyHnsw` or `ctest` locally — this machine's C++ toolchain can't compile the project (see `docs/DEPLOYMENT.md`). CI should be the real proof here.